### PR TITLE
feat(chat): default starter prompts on empty state (0.9.0)

### DIFF
--- a/client/src/components/Chat/Input/ConversationStarters.tsx
+++ b/client/src/components/Chat/Input/ConversationStarters.tsx
@@ -5,6 +5,18 @@ import { useGetAssistantDocsQuery, useGetEndpointsQuery } from '~/data-provider'
 import { getIconEndpoint, getEntity } from '~/utils';
 import { useSubmitMessage } from '~/hooks';
 
+/**
+ * Curated fallback starters for plain-model chats (no agent/assistant-specific
+ * starters). Keeps the empty state from being bare and matches the ChatGPT/Claude
+ * suggestion-chip pattern. Category-style so submitting reads naturally.
+ */
+const DEFAULT_STARTERS = [
+  'Help me write or refine something',
+  'Explain a concept clearly',
+  'Review, debug, or improve some code',
+  'Brainstorm ideas and a plan',
+];
+
 const ConversationStarters = () => {
   const { conversation } = useChatContext();
   const agentsMap = useAgentsMapContext();
@@ -40,11 +52,18 @@ const ConversationStarters = () => {
       return entity.conversation_starters;
     }
 
+    // Agents may intentionally omit starters — honor that (no defaults).
     if (isAgent) {
       return [];
     }
 
-    return documentsMap.get(entity?.id ?? '')?.conversation_starters ?? [];
+    const docStarters = documentsMap.get(entity?.id ?? '')?.conversation_starters;
+    if (docStarters?.length) {
+      return docStarters;
+    }
+
+    // Plain-model chat: fall back to curated defaults so the empty state isn't bare.
+    return DEFAULT_STARTERS;
   }, [documentsMap, isAgent, entity]);
 
   const { submitMessage } = useSubmitMessage();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzochat/chat",
-  "version": "v0.8.3-rc1",
+  "version": "0.9.0",
   "description": "Chat - Unified interface to Agents, LLMs, MCPs and any AI model or OpenAPI documented API with full RAG stack",
   "packageManager": "pnpm@10.27.0",
   "workspaces": [


### PR DESCRIPTION
Adds 4 curated default conversation starters for plain-model chats so the empty state matches the ChatGPT/Claude suggestion-chip pattern. Landing-only, uses existing useSubmitMessage path. Proper semver: 0.8.3-rc1 → 0.9.0 (minor/feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)