### PR TITLE
fix(agents): raise cloud-agent run timeout 30s→180s (long-run 502)

### DIFF
--- a/api/server/services/CloudAgentsClient.js
+++ b/api/server/services/CloudAgentsClient.js
@@ -50,15 +50,25 @@ const MAX_RESPONSE = 4 * 1024 * 1024;
  */
 const MAX_CONCURRENT = Number(process.env.CLOUD_AGENT_MAX_CONCURRENT) || 50;
 
+/**
+ * HTTP timeout (ms) for a cloud call. A run is a real chat completion — a
+ * zen5-mini answer routinely takes ~25-30s and larger models/prompts longer — so
+ * the old 30s default aborted mid-run, surfacing as an in-UI 502 even though the
+ * cloud run finished and recorded. 180s gives real runs headroom; override with
+ * CLOUD_AGENT_TIMEOUT. (List/get are fast; the ceiling only matters for /run.)
+ */
+const DEFAULT_TIMEOUT = Number(process.env.CLOUD_AGENT_TIMEOUT) || 180000;
+
 class CloudAgentsClient {
   /**
    * @param {Object} opts
    * @param {string} opts.endpoint  - Cloud base URL (e.g. https://api.hanzo.ai)
-   * @param {number} [opts.timeout] - HTTP timeout in ms (default 30000; a run is
-   *   a real chat completion so it needs more headroom than a metadata read)
+   * @param {number} [opts.timeout] - HTTP timeout in ms (default DEFAULT_TIMEOUT,
+   *   180s; a run is a real chat completion so it needs far more headroom than a
+   *   metadata read — 30s aborted long runs mid-flight)
    * @param {number} [opts.maxConcurrent] - process-wide in-flight ceiling
    */
-  constructor({ endpoint, timeout = 30000, maxConcurrent = MAX_CONCURRENT }) {
+  constructor({ endpoint, timeout = DEFAULT_TIMEOUT, maxConcurrent = MAX_CONCURRENT }) {
     this.endpoint = endpoint.replace(/\/+$/, '');
     this.timeout = timeout;
     this.maxConcurrent = maxConcurrent;

--- a/api/server/services/CloudAgentsClient.spec.js
+++ b/api/server/services/CloudAgentsClient.spec.js
@@ -210,6 +210,36 @@ describe('CloudAgentsClient', () => {
     });
   });
 
+  describe('run timeout (headroom for long completions)', () => {
+    it('defaults to 180s so a long run is not aborted mid-flight (the 30s -> 502 bug)', () => {
+      const client = new CloudAgentsClient({ endpoint: 'https://api.hanzo.ai' });
+      expect(client.timeout).toBe(180000);
+    });
+
+    it('honors an explicit constructor timeout', () => {
+      const client = new CloudAgentsClient({ endpoint: 'https://api.hanzo.ai', timeout: 5000 });
+      expect(client.timeout).toBe(5000);
+    });
+
+    it('is overridable via CLOUD_AGENT_TIMEOUT (mirrors CLOUD_AGENT_MAX_CONCURRENT)', () => {
+      const saved = process.env.CLOUD_AGENT_TIMEOUT;
+      process.env.CLOUD_AGENT_TIMEOUT = '90000';
+      // DEFAULT_TIMEOUT is read at module load, so re-require in isolation.
+      jest.resetModules();
+      const { CloudAgentsClient: Fresh } = require('./CloudAgentsClient');
+      try {
+        expect(new Fresh({ endpoint: 'https://api.hanzo.ai' }).timeout).toBe(90000);
+      } finally {
+        if (saved === undefined) {
+          delete process.env.CLOUD_AGENT_TIMEOUT;
+        } else {
+          process.env.CLOUD_AGENT_TIMEOUT = saved;
+        }
+        jest.resetModules();
+      }
+    });
+  });
+
   describe('getCloudAgentsClient (env wiring)', () => {
     const saved = {};
     beforeEach(() => {


### PR DESCRIPTION
The cloud-agents run path (`CloudAgentsClient` → `POST api.hanzo.ai/v1/agents/:name/run`) used a hardcoded 30s HTTP timeout. A real run is a chat completion — zen5-mini answers take ~25-30s (measured 28s), larger models/prompts longer — so long runs aborted mid-flight and surfaced in the UI as a 502 even though the cloud run finished and recorded.

Fix: default timeout 30s→180s, env-configurable via `CLOUD_AGENT_TIMEOUT` (mirrors the existing `CLOUD_AGENT_MAX_CONCURRENT`). Only `/run` needs the headroom; list/get stay fast.

Pairs with the ops change adding `HANZO_CLOUD_URL` to the `maxpower-chat` tenant so the cloud-agents bridge is enabled there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)