### PR TITLE
fix(mcp): full connection/transport port (proxy + response-size caps + WS SSRF) + wire suite into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,5 +66,15 @@ jobs:
         MEILI_HOST: http://localhost:7700
         MEILI_MASTER_KEY: test_master_key
 
+    # Gate against tests-without-implementation drift in the MCP connection/
+    # transport layer (proxy, response-size caps, WS SSRF, allowedAddresses).
+    # These suites live in packages/api and were never run by this workflow —
+    # which is how the connection.ts port drifted from its byte-identical tests.
+    # A future half-port now fails here loudly.
+    - name: Run MCP connection/transport tests
+      run: cd packages/api && pnpm run test:transport
+      env:
+        NODE_ENV: test
+
     - name: Run client tests
       run: pnpm run test:client

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,7 @@
     "build:watch:prod": "rollup -c -w --bundleConfigAsCjs",
     "test": "jest --coverage --watch --testPathIgnorePatterns=\"\\.*integration\\.|\\.*helper\\.\"",
     "test:ci": "jest --coverage --ci --testPathIgnorePatterns=\"\\.*integration\\.|\\.*helper\\.\"",
+    "test:transport": "jest --ci --coverage=false --testPathPatterns=\"MCPConnection|MCPRedirectSSRFGuard|reconnection-storm|MCPManager|auth/domain\\.spec|auth/agent\\.spec|oauth/hardenedFetch|oauth/OAuthReconnection\"",
     "test:cache-integration:core": "jest --testPathPatterns=\"src/cache/.*\\.cache_integration\\.spec\\.ts$\" --coverage=false",
     "test:cache-integration:cluster": "jest --testPathPatterns=\"src/cluster/.*\\.cache_integration\\.spec\\.ts$\" --coverage=false --runInBand",
     "test:cache-integration:mcp": "jest --testPathPatterns=\"src/mcp/.*\\.cache_integration\\.spec\\.ts$\" --coverage=false",

--- a/packages/api/src/auth/agent.spec.ts
+++ b/packages/api/src/auth/agent.spec.ts
@@ -7,11 +7,20 @@ jest.mock('node:dns', () => {
 });
 
 import dns from 'node:dns';
+import http from 'node:http';
+import type { LookupFunction } from 'node:net';
 import { createSSRFSafeAgents, createSSRFSafeUndiciConnect } from './agent';
 
-type LookupCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: string | dns.LookupAddress[],
+  family?: number,
+) => void;
 
 const mockedDnsLookup = dns.lookup as jest.MockedFunction<typeof dns.lookup>;
+const httpAgentPrototype = http.Agent.prototype as unknown as {
+  createConnection: (options: Record<string, unknown>) => unknown;
+};
 
 function mockDnsResult(address: string, family: number): void {
   mockedDnsLookup.mockImplementation(((
@@ -20,6 +29,16 @@ function mockDnsResult(address: string, family: number): void {
     callback: LookupCallback,
   ) => {
     callback(null, address, family);
+  }) as never);
+}
+
+function mockDnsAllResult(addresses: dns.LookupAddress[]): void {
+  mockedDnsLookup.mockImplementation(((
+    _hostname: string,
+    _options: unknown,
+    callback: LookupCallback,
+  ) => {
+    callback(null, addresses);
   }) as never);
 }
 
@@ -35,6 +54,7 @@ function mockDnsError(err: NodeJS.ErrnoException): void {
 
 describe('createSSRFSafeAgents', () => {
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -50,6 +70,29 @@ describe('createSSRFSafeAgents', () => {
       createConnection: (opts: Record<string, unknown>) => unknown;
     };
     expect(internal.createConnection).toBeInstanceOf(Function);
+  });
+
+  it('should scope allowedAddresses by the request port in the HTTP agent lookup', async () => {
+    mockDnsResult('10.0.0.5', 4);
+    let lookupError: NodeJS.ErrnoException | null = null;
+    jest.spyOn(httpAgentPrototype, 'createConnection').mockImplementation(((
+      options: Record<string, unknown>,
+    ) => {
+      const lookup = options.lookup as LookupFunction;
+      lookup('private.example.com', {}, (err) => {
+        lookupError = err;
+      });
+      return {};
+    }) as never);
+
+    const agents = createSSRFSafeAgents(['10.0.0.5:11434']);
+    const internal = agents.httpAgent as unknown as {
+      createConnection: (opts: Record<string, unknown>) => unknown;
+    };
+    internal.createConnection({ host: 'private.example.com', port: 22 });
+
+    expect(lookupError).toBeTruthy();
+    expect(lookupError!.code).toBe('ESSRF');
   });
 });
 
@@ -94,6 +137,73 @@ describe('createSSRFSafeUndiciConnect', () => {
     expect(result.address).toBe('93.184.216.34');
   });
 
+  it('lookup should block private IPs when DNS returns all addresses', async () => {
+    mockDnsAllResult([{ address: '127.0.0.1', family: 4 }]);
+    const connect = createSSRFSafeUndiciConnect();
+
+    const result = await new Promise<{ err: NodeJS.ErrnoException | null }>((resolve) => {
+      connect.lookup('localhost', { all: true }, (err) => {
+        resolve({ err });
+      });
+    });
+
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('lookup should allow public IPs when DNS returns all addresses', async () => {
+    const addresses = [{ address: '93.184.216.34', family: 4 }];
+    mockDnsAllResult(addresses);
+    const connect = createSSRFSafeUndiciConnect();
+
+    const result = await new Promise<{
+      err: NodeJS.ErrnoException | null;
+      address: string | dns.LookupAddress[];
+    }>((resolve) => {
+      connect.lookup('example.com', { all: true }, (err, address) => {
+        resolve({ err, address });
+      });
+    });
+
+    expect(result.err).toBeNull();
+    expect(result.address).toEqual(addresses);
+  });
+
+  it('lookup should block mixed public and private all-address results', async () => {
+    mockDnsAllResult([
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.1', family: 4 },
+    ]);
+    const connect = createSSRFSafeUndiciConnect();
+
+    const result = await new Promise<{ err: NodeJS.ErrnoException | null }>((resolve) => {
+      connect.lookup('rebinding.example.com', { all: true }, (err) => {
+        resolve({ err });
+      });
+    });
+
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('lookup should honor allowedAddresses when DNS returns all addresses', async () => {
+    const addresses = [{ address: '10.0.0.5', family: 4 }];
+    mockDnsAllResult(addresses);
+    const connect = createSSRFSafeUndiciConnect(['10.0.0.5:11434'], '11434');
+
+    const result = await new Promise<{
+      err: NodeJS.ErrnoException | null;
+      address: string | dns.LookupAddress[];
+    }>((resolve) => {
+      connect.lookup('private.example.com', { all: true }, (err, address) => {
+        resolve({ err, address });
+      });
+    });
+
+    expect(result.err).toBeNull();
+    expect(result.address).toEqual(addresses);
+  });
+
   it('lookup should forward DNS errors', async () => {
     const dnsError = Object.assign(new Error('ENOTFOUND'), {
       code: 'ENOTFOUND',
@@ -109,5 +219,114 @@ describe('createSSRFSafeUndiciConnect', () => {
 
     expect(result.err).toBeTruthy();
     expect(result.err!.code).toBe('ENOTFOUND');
+  });
+});
+
+/**
+ * Connect-time exemption is the TOCTOU-safe layer: pre-flight validation can
+ * be bypassed by DNS rebinding, but the agent's `lookup` runs on every TCP
+ * connect and must honor `allowedAddresses` consistently. These tests cover
+ * the runtime path that the domain.ts spec doesn't reach.
+ */
+describe('SSRF agents — allowedAddresses exemption', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function runLookup(lookup: LookupFunction, hostname: string) {
+    return new Promise<{ err: NodeJS.ErrnoException | null; address: string }>((resolve) => {
+      (lookup as (h: string, o: object, cb: LookupCallback) => void)(hostname, {}, (err, address) =>
+        resolve({ err, address: address as string }),
+      );
+    });
+  }
+
+  it('exempts a hostname literal on the admin-permitted port', async () => {
+    mockDnsResult('10.0.0.5', 4);
+    const { lookup } = createSSRFSafeUndiciConnect(['ollama.internal:11434'], '11434');
+    const result = await runLookup(lookup, 'ollama.internal');
+    expect(result.err).toBeNull();
+    expect(result.address).toBe('10.0.0.5');
+  });
+
+  it('exempts a private IP on the admin-permitted port (DNS resolves to it)', async () => {
+    mockDnsResult('10.0.0.5', 4);
+    const { lookup } = createSSRFSafeUndiciConnect(['10.0.0.5:11434'], '11434');
+    const result = await runLookup(lookup, 'private.example.com');
+    expect(result.err).toBeNull();
+    expect(result.address).toBe('10.0.0.5');
+  });
+
+  it('blocks a private IP on a different port of an allowed address', async () => {
+    mockDnsResult('10.0.0.5', 4);
+    const { lookup } = createSSRFSafeUndiciConnect(['10.0.0.5:11434'], '22');
+    const result = await runLookup(lookup, 'private.example.com');
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('ignores legacy bare allowedAddresses entries', async () => {
+    mockDnsResult('10.0.0.5', 4);
+    const { lookup } = createSSRFSafeUndiciConnect(['10.0.0.5'], '11434');
+    const result = await runLookup(lookup, 'private.example.com');
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('still blocks an unlisted private IP when allowedAddresses is set', async () => {
+    mockDnsResult('192.168.1.42', 4);
+    const { lookup } = createSSRFSafeUndiciConnect(['10.0.0.5:11434'], '11434');
+    const result = await runLookup(lookup, 'other.private.example.com');
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('drops public-IP entries from allowedAddresses (private-IP scope only)', async () => {
+    // Admin mistakenly listed a public IP. It must NOT grant exemption.
+    mockDnsResult('10.0.0.5', 4);
+    const { lookup } = createSSRFSafeUndiciConnect(['8.8.8.8:53'], '53');
+    const result = await runLookup(lookup, 'private.example.com');
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('drops URL/CIDR/whitespace entries from allowedAddresses', async () => {
+    mockDnsResult('10.0.0.5', 4);
+    const { lookup } = createSSRFSafeUndiciConnect(
+      ['http://10.0.0.5', '10.0.0.0/24', ' 10.0.0.5 '],
+      '11434',
+    );
+    // Even though the value 10.0.0.5 is among the admin entries, none of them
+    // pass the schema-shape filter (URL, CIDR, embedded whitespace), so no
+    // exemption is granted.
+    const result = await runLookup(lookup, 'private.example.com');
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('createSSRFSafeAgents propagates the exemption-aware lookup to both agents', async () => {
+    // The agent factory wraps `createConnection` to inject a custom lookup.
+    // The HTTP wrapper is covered above; this keeps the shared lookup factory
+    // expectation explicit for the exemption list.
+    mockDnsResult('10.0.0.5', 4);
+    const agents = createSSRFSafeAgents(['10.0.0.5:11434']);
+    expect(agents.httpAgent).toBeDefined();
+    expect(agents.httpsAgent).toBeDefined();
+
+    // The undici-connect path uses the same `buildSSRFSafeLookup` factory, so
+    // verifying the exemption holds there is sufficient evidence that the
+    // agent factory built the right lookup.
+    const { lookup } = createSSRFSafeUndiciConnect(['10.0.0.5:11434'], '11434');
+    const result = await runLookup(lookup, 'private.example.com');
+    expect(result.err).toBeNull();
+    expect(result.address).toBe('10.0.0.5');
+  });
+
+  it('default lookup (no exemption list) blocks private IPs', async () => {
+    mockDnsResult('10.0.0.5', 4);
+    const { lookup } = createSSRFSafeUndiciConnect();
+    const result = await runLookup(lookup, 'private.example.com');
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
   });
 });

--- a/packages/api/src/auth/agent.ts
+++ b/packages/api/src/auth/agent.ts
@@ -2,52 +2,106 @@ import dns from 'node:dns';
 import http from 'node:http';
 import https from 'node:https';
 import type { LookupFunction } from 'node:net';
-import { isPrivateIP } from './domain';
+import {
+  normalizePort,
+  normalizeAllowedAddressesSet,
+  isAddressInAllowedSet,
+} from './allowedAddresses';
+import { isPrivateIP } from './ip';
 
-/**
- * Returns the first resolved address that is private/reserved, or null.
- * `dns.lookup` yields a single string when called without `{ all: true }` and a
- * `LookupAddress[]` when called with it. undici's connector asks for all
- * addresses, so a `typeof address === 'string'` guard silently fails open on
- * the array shape — a hostname resolving to a private IP would pass unchecked.
- * Normalize both shapes to a flat list and reject if ANY entry is private.
- */
-function findBlockedLookupAddress(address: string | dns.LookupAddress[]): string | null {
-  const addresses = Array.isArray(address) ? address.map((entry) => entry.address) : [address];
-  return addresses.find((entry) => isPrivateIP(entry)) ?? null;
+type LookupResult = string | dns.LookupAddress[];
+
+function createSSRFLookupError(hostname: string, address: string): NodeJS.ErrnoException {
+  return Object.assign(
+    new Error(`SSRF protection: ${hostname} resolved to blocked address ${address}`),
+    { code: 'ESSRF' },
+  ) as NodeJS.ErrnoException;
 }
 
-/** DNS lookup wrapper that blocks resolution to private/reserved IP addresses */
-const ssrfSafeLookup: LookupFunction = (hostname, options, callback) => {
-  dns.lookup(hostname, options, (err, address, family) => {
-    if (err) {
-      callback(err, '', 0);
-      return;
-    }
-    const blockedAddress = findBlockedLookupAddress(address as string | dns.LookupAddress[]);
-    if (blockedAddress) {
-      const ssrfError = Object.assign(
-        new Error(`SSRF protection: ${hostname} resolved to blocked address ${blockedAddress}`),
-        { code: 'ESSRF' },
-      ) as NodeJS.ErrnoException;
-      callback(ssrfError, blockedAddress, family as number);
-      return;
-    }
-    callback(null, address as string, family as number);
-  });
-};
+function getBlockedLookupAddress(
+  lookupResult: LookupResult,
+  hostnameAllowed: boolean,
+  exemptSet: Set<string> | null,
+  normalizedPort: string,
+): string | null {
+  if (hostnameAllowed) {
+    return null;
+  }
+
+  const addresses = Array.isArray(lookupResult)
+    ? lookupResult.map(({ address }) => address)
+    : [lookupResult];
+
+  return (
+    addresses.find(
+      (address) =>
+        isPrivateIP(address) && !isAddressInAllowedSet(address, exemptSet, normalizedPort),
+    ) ?? null
+  );
+}
+
+/**
+ * Builds a DNS lookup wrapper that blocks resolution to private/reserved IP
+ * addresses. When `allowedAddresses` is provided, hostname/IP + port pairs
+ * matching the list bypass the block — admins can permit known-good internal
+ * services (self-hosted Ollama, Docker host, etc.) without disabling SSRF
+ * protection for every port on the same host.
+ *
+ * The exemption list is pre-normalized once at construction so the per-
+ * connection lookup runs an O(1) Set membership check. Normalization and
+ * scoping rules live in `./allowedAddresses`, shared with the preflight
+ * helper in `./domain` so the two layers cannot diverge.
+ */
+function buildSSRFSafeLookup(
+  allowedAddresses?: string[] | null,
+  port?: string | number | null,
+): LookupFunction {
+  const exemptSet = normalizeAllowedAddressesSet(allowedAddresses);
+  const normalizedPort = normalizePort(port);
+  return (hostname, options, callback) => {
+    const hostnameAllowed = isAddressInAllowedSet(hostname, exemptSet, normalizedPort);
+    dns.lookup(hostname, options, (err, address, family) => {
+      if (err) {
+        callback(err, '', 0);
+        return;
+      }
+
+      const blockedAddress = getBlockedLookupAddress(
+        address,
+        hostnameAllowed,
+        exemptSet,
+        normalizedPort,
+      );
+      if (blockedAddress) {
+        callback(createSSRFLookupError(hostname, blockedAddress), blockedAddress, family);
+        return;
+      }
+
+      callback(null, address, family);
+    });
+  };
+}
+
+/** Default lookup with no exemptions. Kept for callers that don't need allowedAddresses. */
+const ssrfSafeLookup: LookupFunction = buildSSRFSafeLookup();
 
 /** Internal agent shape exposing createConnection (exists at runtime but not in TS types) */
 type AgentInternal = {
   createConnection: (options: Record<string, unknown>, oncreate?: unknown) => unknown;
 };
 
+function getConnectionPort(options: Record<string, unknown>): string {
+  return normalizePort(options.port ?? options.defaultPort);
+}
+
 /** Patches an agent instance to inject SSRF-safe DNS lookup at connect time */
-function withSSRFProtection<T extends http.Agent>(agent: T): T {
+function withSSRFProtection<T extends http.Agent>(agent: T, allowedAddresses?: string[] | null): T {
   const internal = agent as unknown as AgentInternal;
   const origCreate = internal.createConnection.bind(agent);
   internal.createConnection = (options: Record<string, unknown>, oncreate?: unknown) => {
-    options.lookup = ssrfSafeLookup;
+    options.lookup = allowedAddresses?.length
+      ? buildSSRFSafeLookup(allowedAddresses, getConnectionPort(options))
+      : ssrfSafeLookup;
     return origCreate(options, oncreate);
   };
   return agent;
@@ -58,18 +112,33 @@ function withSSRFProtection<T extends http.Agent>(agent: T): T {
  * Provides TOCTOU-safe SSRF protection by validating the resolved IP at connect time,
  * preventing DNS rebinding attacks where a hostname resolves to a public IP during
  * pre-validation but to a private IP when the actual connection is made.
+ *
+ * @param allowedAddresses - Optional admin exemption list of host:port pairs that bypass the block.
  */
-export function createSSRFSafeAgents(): { httpAgent: http.Agent; httpsAgent: https.Agent } {
+export function createSSRFSafeAgents(allowedAddresses?: string[] | null): {
+  httpAgent: http.Agent;
+  httpsAgent: https.Agent;
+} {
   return {
-    httpAgent: withSSRFProtection(new http.Agent()),
-    httpsAgent: withSSRFProtection(new https.Agent()),
+    httpAgent: withSSRFProtection(new http.Agent(), allowedAddresses),
+    httpsAgent: withSSRFProtection(new https.Agent(), allowedAddresses),
   };
 }
 
 /**
  * Returns undici-compatible `connect` options with SSRF-safe DNS lookup.
  * Pass the result as the `connect` property when constructing an undici `Agent`.
+ *
+ * @param allowedAddresses - Optional admin exemption list of host:port pairs that bypass the block.
  */
-export function createSSRFSafeUndiciConnect(): { lookup: LookupFunction } {
-  return { lookup: ssrfSafeLookup };
+export function createSSRFSafeUndiciConnect(
+  allowedAddresses?: string[] | null,
+  port?: string | number | null,
+): {
+  lookup: LookupFunction;
+} {
+  const lookup = allowedAddresses?.length
+    ? buildSSRFSafeLookup(allowedAddresses, port)
+    : ssrfSafeLookup;
+  return { lookup };
 }

--- a/packages/api/src/auth/domain.spec.ts
+++ b/packages/api/src/auth/domain.spec.ts
@@ -7,11 +7,14 @@ import { lookup } from 'node:dns/promises';
 import {
   extractMCPServerDomain,
   isActionDomainAllowed,
+  isAddressAllowed,
   isEmailDomainAllowed,
+  isOAuthUrlAllowed,
   isMCPDomainAllowed,
   isPrivateIP,
   isSSRFTarget,
   resolveHostnameSSRF,
+  validateEndpointURL,
 } from './domain';
 
 const mockedLookup = lookup as jest.MockedFunction<typeof lookup>;
@@ -153,8 +156,9 @@ describe('isSSRFTarget', () => {
       expect(isSSRFTarget('169.254.0.1')).toBe(true);
     });
 
-    it('should block 0.0.0.0', () => {
+    it('should block 0.0.0.0/8 (current network)', () => {
       expect(isSSRFTarget('0.0.0.0')).toBe(true);
+      expect(isSSRFTarget('0.1.2.3')).toBe(true);
     });
 
     it('should allow public IPs', () => {
@@ -175,6 +179,20 @@ describe('isSSRFTarget', () => {
       expect(isSSRFTarget('fc00::1')).toBe(true);
       expect(isSSRFTarget('fd00::1')).toBe(true);
       expect(isSSRFTarget('fe80::1')).toBe(true);
+    });
+
+    it('should block full fe80::/10 link-local range (fe80–febf)', () => {
+      expect(isSSRFTarget('fe90::1')).toBe(true);
+      expect(isSSRFTarget('fea0::1')).toBe(true);
+      expect(isSSRFTarget('feb0::1')).toBe(true);
+      expect(isSSRFTarget('febf::1')).toBe(true);
+      expect(isSSRFTarget('fec0::1')).toBe(false);
+    });
+
+    it('should NOT false-positive on hostnames whose first label resembles a link-local prefix', () => {
+      expect(isSSRFTarget('fe90.example.com')).toBe(false);
+      expect(isSSRFTarget('fea0.api.io')).toBe(false);
+      expect(isSSRFTarget('febf.service.net')).toBe(false);
     });
   });
 
@@ -230,8 +248,36 @@ describe('isPrivateIP', () => {
       expect(isPrivateIP('169.254.0.1')).toBe(true);
     });
 
-    it('should detect 0.0.0.0', () => {
+    it('should detect 0.0.0.0/8 (current network)', () => {
       expect(isPrivateIP('0.0.0.0')).toBe(true);
+      expect(isPrivateIP('0.1.2.3')).toBe(true);
+    });
+
+    it('should detect 100.64.0.0/10 (CGNAT / shared address space)', () => {
+      expect(isPrivateIP('100.64.0.1')).toBe(true);
+      expect(isPrivateIP('100.127.255.255')).toBe(true);
+      expect(isPrivateIP('100.63.255.255')).toBe(false);
+      expect(isPrivateIP('100.128.0.1')).toBe(false);
+    });
+
+    it('should detect 192.0.0.0/24 (IETF protocol assignments)', () => {
+      expect(isPrivateIP('192.0.0.1')).toBe(true);
+      expect(isPrivateIP('192.0.0.255')).toBe(true);
+      expect(isPrivateIP('192.0.1.1')).toBe(false);
+    });
+
+    it('should detect 198.18.0.0/15 (benchmarking)', () => {
+      expect(isPrivateIP('198.18.0.1')).toBe(true);
+      expect(isPrivateIP('198.19.255.255')).toBe(true);
+      expect(isPrivateIP('198.17.0.1')).toBe(false);
+      expect(isPrivateIP('198.20.0.1')).toBe(false);
+    });
+
+    it('should detect 224.0.0.0/4 (multicast) and 240.0.0.0/4 (reserved)', () => {
+      expect(isPrivateIP('224.0.0.1')).toBe(true);
+      expect(isPrivateIP('239.255.255.255')).toBe(true);
+      expect(isPrivateIP('240.0.0.1')).toBe(true);
+      expect(isPrivateIP('255.255.255.255')).toBe(true);
     });
 
     it('should allow public IPs', () => {
@@ -248,10 +294,17 @@ describe('isPrivateIP', () => {
       expect(isPrivateIP('[::1]')).toBe(true);
     });
 
-    it('should detect unique local (fc/fd) and link-local (fe80)', () => {
+    it('should detect unique local (fc/fd) and link-local (fe80::/10)', () => {
       expect(isPrivateIP('fc00::1')).toBe(true);
       expect(isPrivateIP('fd00::1')).toBe(true);
       expect(isPrivateIP('fe80::1')).toBe(true);
+      expect(isPrivateIP('fe90::1')).toBe(true);
+      expect(isPrivateIP('fea0::1')).toBe(true);
+      expect(isPrivateIP('feb0::1')).toBe(true);
+      expect(isPrivateIP('febf::1')).toBe(true);
+      expect(isPrivateIP('[fe90::1]')).toBe(true);
+      expect(isPrivateIP('fec0::1')).toBe(false);
+      expect(isPrivateIP('fe90.example.com')).toBe(false);
     });
   });
 
@@ -267,6 +320,144 @@ describe('isPrivateIP', () => {
       expect(isPrivateIP('::ffff:8.8.8.8')).toBe(false);
       expect(isPrivateIP('::ffff:93.184.216.34')).toBe(false);
     });
+  });
+});
+
+describe('isPrivateIP - IPv4-mapped IPv6 hex-normalized form (CVE-style SSRF bypass)', () => {
+  /**
+   * Node.js URL parser normalizes IPv4-mapped IPv6 from dotted-decimal to hex:
+   *   new URL('http://[::ffff:169.254.169.254]/').hostname → '::ffff:a9fe:a9fe'
+   *
+   * These tests confirm whether isPrivateIP catches the hex form that actually
+   * reaches it in production (via parseDomainSpec → new URL → hostname).
+   */
+  it('should detect hex-normalized AWS metadata address (::ffff:a9fe:a9fe)', () => {
+    // ::ffff:169.254.169.254 → hex form after URL parsing
+    expect(isPrivateIP('::ffff:a9fe:a9fe')).toBe(true);
+  });
+
+  it('should detect hex-normalized loopback (::ffff:7f00:1)', () => {
+    // ::ffff:127.0.0.1 → hex form after URL parsing
+    expect(isPrivateIP('::ffff:7f00:1')).toBe(true);
+  });
+
+  it('should detect hex-normalized 192.168.x.x (::ffff:c0a8:101)', () => {
+    // ::ffff:192.168.1.1 → hex form after URL parsing
+    expect(isPrivateIP('::ffff:c0a8:101')).toBe(true);
+  });
+
+  it('should detect hex-normalized 10.x.x.x (::ffff:a00:1)', () => {
+    // ::ffff:10.0.0.1 → hex form after URL parsing
+    expect(isPrivateIP('::ffff:a00:1')).toBe(true);
+  });
+
+  it('should detect hex-normalized 172.16.x.x (::ffff:ac10:1)', () => {
+    // ::ffff:172.16.0.1 → hex form after URL parsing
+    expect(isPrivateIP('::ffff:ac10:1')).toBe(true);
+  });
+
+  it('should detect hex-normalized 0.0.0.0 (::ffff:0:0)', () => {
+    // ::ffff:0.0.0.0 → hex form after URL parsing
+    expect(isPrivateIP('::ffff:0:0')).toBe(true);
+  });
+
+  it('should allow hex-normalized public IPs (::ffff:808:808 = 8.8.8.8)', () => {
+    expect(isPrivateIP('::ffff:808:808')).toBe(false);
+  });
+
+  it('should detect IPv4-compatible addresses without ffff prefix (::XXXX:XXXX)', () => {
+    expect(isPrivateIP('::7f00:1')).toBe(true);
+    expect(isPrivateIP('::a9fe:a9fe')).toBe(true);
+    expect(isPrivateIP('::c0a8:101')).toBe(true);
+    expect(isPrivateIP('::a00:1')).toBe(true);
+  });
+
+  it('should allow public IPs in IPv4-compatible form', () => {
+    expect(isPrivateIP('::808:808')).toBe(false);
+  });
+
+  it('should detect 6to4 addresses embedding private IPv4 (2002:XXXX:XXXX::)', () => {
+    expect(isPrivateIP('2002:7f00:1::')).toBe(true);
+    expect(isPrivateIP('2002:a9fe:a9fe::')).toBe(true);
+    expect(isPrivateIP('2002:c0a8:101::')).toBe(true);
+    expect(isPrivateIP('2002:a00:1::')).toBe(true);
+  });
+
+  it('should allow 6to4 addresses embedding public IPv4', () => {
+    expect(isPrivateIP('2002:808:808::')).toBe(false);
+  });
+
+  it('should detect NAT64 addresses embedding private IPv4 (64:ff9b::XXXX:XXXX)', () => {
+    expect(isPrivateIP('64:ff9b::7f00:1')).toBe(true);
+    expect(isPrivateIP('64:ff9b::a9fe:a9fe')).toBe(true);
+  });
+
+  it('should detect Teredo addresses with complement-encoded private IPv4 (RFC 4380)', () => {
+    // Teredo stores external IPv4 as bitwise complement in last 32 bits
+    // 127.0.0.1 → complement: 0x80ff:0xfffe
+    expect(isPrivateIP('2001::80ff:fffe')).toBe(true);
+    // 169.254.169.254 → complement: 0x5601:0x5601
+    expect(isPrivateIP('2001::5601:5601')).toBe(true);
+    // 10.0.0.1 → complement: 0xf5ff:0xfffe
+    expect(isPrivateIP('2001::f5ff:fffe')).toBe(true);
+  });
+
+  it('should allow Teredo addresses with complement-encoded public IPv4', () => {
+    // 8.8.8.8 → complement: 0xf7f7:0xf7f7
+    expect(isPrivateIP('2001::f7f7:f7f7')).toBe(false);
+  });
+
+  it('should confirm URL parser produces the hex form that bypasses dotted regex', () => {
+    // This test documents the exact normalization gap
+    const hostname = new URL('http://[::ffff:169.254.169.254]/').hostname.replace(/^\[|\]$/g, '');
+    expect(hostname).toBe('::ffff:a9fe:a9fe'); // hex, not dotted
+    // The hostname that actually reaches isPrivateIP must be caught
+    expect(isPrivateIP(hostname)).toBe(true);
+  });
+});
+
+describe('isActionDomainAllowed - IPv4-mapped IPv6 hex SSRF bypass (end-to-end)', () => {
+  beforeEach(() => {
+    mockedLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should block http://[::ffff:169.254.169.254]/ (AWS metadata via IPv6)', async () => {
+    expect(await isActionDomainAllowed('http://[::ffff:169.254.169.254]/', null)).toBe(false);
+  });
+
+  it('should block http://[::ffff:127.0.0.1]/ (loopback via IPv6)', async () => {
+    expect(await isActionDomainAllowed('http://[::ffff:127.0.0.1]/', null)).toBe(false);
+  });
+
+  it('should block http://[::ffff:192.168.1.1]/ (private via IPv6)', async () => {
+    expect(await isActionDomainAllowed('http://[::ffff:192.168.1.1]/', null)).toBe(false);
+  });
+
+  it('should block http://[::ffff:10.0.0.1]/ (private via IPv6)', async () => {
+    expect(await isActionDomainAllowed('http://[::ffff:10.0.0.1]/', null)).toBe(false);
+  });
+
+  it('should allow http://[::ffff:8.8.8.8]/ (public via IPv6)', async () => {
+    expect(await isActionDomainAllowed('http://[::ffff:8.8.8.8]/', null)).toBe(true);
+  });
+
+  it('should block IPv4-compatible IPv6 without ffff prefix', async () => {
+    expect(await isActionDomainAllowed('http://[::127.0.0.1]/', null)).toBe(false);
+    expect(await isActionDomainAllowed('http://[::169.254.169.254]/', null)).toBe(false);
+    expect(await isActionDomainAllowed('http://[0:0:0:0:0:0:127.0.0.1]/', null)).toBe(false);
+  });
+
+  it('should block 6to4 addresses embedding private IPv4', async () => {
+    expect(await isActionDomainAllowed('http://[2002:7f00:1::]/', null)).toBe(false);
+    expect(await isActionDomainAllowed('http://[2002:a9fe:a9fe::]/', null)).toBe(false);
+  });
+
+  it('should block NAT64 addresses embedding private IPv4', async () => {
+    expect(await isActionDomainAllowed('http://[64:ff9b::127.0.0.1]/', null)).toBe(false);
+    expect(await isActionDomainAllowed('http://[64:ff9b::169.254.169.254]/', null)).toBe(false);
   });
 });
 
@@ -298,14 +489,50 @@ describe('resolveHostnameSSRF', () => {
     expect(await resolveHostnameSSRF('example.com')).toBe(false);
   });
 
-  it('should skip literal IPv4 addresses (handled by isSSRFTarget)', async () => {
-    expect(await resolveHostnameSSRF('169.254.169.254')).toBe(false);
+  it('should detect private literal IPv4 addresses without DNS lookup', async () => {
+    expect(await resolveHostnameSSRF('169.254.169.254')).toBe(true);
+    expect(await resolveHostnameSSRF('127.0.0.1')).toBe(true);
+    expect(await resolveHostnameSSRF('10.0.0.1')).toBe(true);
     expect(mockedLookup).not.toHaveBeenCalled();
   });
 
-  it('should skip literal IPv6 addresses', async () => {
-    expect(await resolveHostnameSSRF('::1')).toBe(false);
+  it('should allow public literal IPv4 addresses without DNS lookup', async () => {
+    expect(await resolveHostnameSSRF('8.8.8.8')).toBe(false);
+    expect(await resolveHostnameSSRF('93.184.216.34')).toBe(false);
     expect(mockedLookup).not.toHaveBeenCalled();
+  });
+
+  it('should detect private IPv6 literals without DNS lookup', async () => {
+    expect(await resolveHostnameSSRF('::1')).toBe(true);
+    expect(await resolveHostnameSSRF('fc00::1')).toBe(true);
+    expect(await resolveHostnameSSRF('fe80::1')).toBe(true);
+    expect(await resolveHostnameSSRF('fe90::1')).toBe(true);
+    expect(await resolveHostnameSSRF('febf::1')).toBe(true);
+    expect(mockedLookup).not.toHaveBeenCalled();
+  });
+
+  it('should detect hex-normalized IPv4-mapped IPv6 literals', async () => {
+    expect(await resolveHostnameSSRF('::ffff:a9fe:a9fe')).toBe(true);
+    expect(await resolveHostnameSSRF('::ffff:7f00:1')).toBe(true);
+    expect(await resolveHostnameSSRF('[::ffff:a9fe:a9fe]')).toBe(true);
+    expect(mockedLookup).not.toHaveBeenCalled();
+  });
+
+  it('should allow public IPv6 literals without DNS lookup', async () => {
+    expect(await resolveHostnameSSRF('2001:db8::1')).toBe(false);
+    expect(await resolveHostnameSSRF('::ffff:808:808')).toBe(false);
+    expect(mockedLookup).not.toHaveBeenCalled();
+  });
+
+  it('should detect private IPv6 addresses returned from DNS lookup', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '::1', family: 6 }] as never);
+    expect(await resolveHostnameSSRF('ipv6-loopback.example.com')).toBe(true);
+
+    mockedLookup.mockResolvedValueOnce([{ address: 'fc00::1', family: 6 }] as never);
+    expect(await resolveHostnameSSRF('ula.example.com')).toBe(true);
+
+    mockedLookup.mockResolvedValueOnce([{ address: '::ffff:a9fe:a9fe', family: 6 }] as never);
+    expect(await resolveHostnameSSRF('meta.example.com')).toBe(true);
   });
 
   it('should fail open on DNS resolution failure', async () => {
@@ -822,8 +1049,37 @@ describe('isMCPDomainAllowed', () => {
   });
 
   describe('invalid URL handling', () => {
-    it('should allow config with invalid URL (treated as stdio)', async () => {
+    it('should reject invalid URL when allowlist is configured', async () => {
       const config = { url: 'not-a-valid-url' };
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(false);
+    });
+
+    it('should reject templated URL when allowlist is configured', async () => {
+      const config = { url: 'http://{{CUSTOM_HOST}}/mcp' };
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(false);
+    });
+
+    it('should allow invalid URL when no allowlist is configured (defers to connection-level SSRF)', async () => {
+      const config = { url: 'http://{{CUSTOM_HOST}}/mcp' };
+      expect(await isMCPDomainAllowed(config, null)).toBe(true);
+      expect(await isMCPDomainAllowed(config, undefined)).toBe(true);
+      expect(await isMCPDomainAllowed(config, [])).toBe(true);
+    });
+
+    it('should allow config with whitespace-only URL (treated as absent)', async () => {
+      const config = { url: '   ' };
+      expect(await isMCPDomainAllowed(config, [])).toBe(true);
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(true);
+      expect(await isMCPDomainAllowed(config, null)).toBe(true);
+    });
+
+    it('should allow config with empty string URL (treated as absent)', async () => {
+      const config = { url: '' };
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(true);
+    });
+
+    it('should allow config with no url property (stdio)', async () => {
+      const config = { command: 'node', args: ['server.js'] };
       expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(true);
     });
   });
@@ -913,6 +1169,517 @@ describe('isMCPDomainAllowed', () => {
       expect(await isMCPDomainAllowed({ url: 'https://example.com' }, ['example.com'])).toBe(true);
       expect(await isMCPDomainAllowed({ url: 'ws://example.com' }, ['example.com'])).toBe(true);
       expect(await isMCPDomainAllowed({ url: 'wss://example.com' }, ['example.com'])).toBe(true);
+    });
+  });
+
+  describe('IPv4-mapped IPv6 hex SSRF bypass', () => {
+    it('should block MCP server targeting AWS metadata via IPv6-mapped address', async () => {
+      const config = { url: 'http://[::ffff:169.254.169.254]/mcp' };
+      expect(await isMCPDomainAllowed(config, null)).toBe(false);
+    });
+
+    it('should block MCP server targeting loopback via IPv6-mapped address', async () => {
+      const config = { url: 'http://[::ffff:127.0.0.1]/mcp' };
+      expect(await isMCPDomainAllowed(config, null)).toBe(false);
+    });
+
+    it('should block MCP server targeting private range via IPv6-mapped address', async () => {
+      expect(await isMCPDomainAllowed({ url: 'http://[::ffff:10.0.0.1]/mcp' }, null)).toBe(false);
+      expect(await isMCPDomainAllowed({ url: 'http://[::ffff:192.168.1.1]/mcp' }, null)).toBe(
+        false,
+      );
+    });
+
+    it('should block WebSocket MCP targeting private range via IPv6-mapped address', async () => {
+      expect(await isMCPDomainAllowed({ url: 'ws://[::ffff:127.0.0.1]/mcp' }, null)).toBe(false);
+      expect(await isMCPDomainAllowed({ url: 'wss://[::ffff:10.0.0.1]/mcp' }, null)).toBe(false);
+    });
+
+    it('should allow MCP server targeting public IP via IPv6-mapped address', async () => {
+      const config = { url: 'http://[::ffff:8.8.8.8]/mcp' };
+      expect(await isMCPDomainAllowed(config, null)).toBe(true);
+    });
+
+    it('should block MCP server targeting 6to4 embedded private IPv4', async () => {
+      expect(await isMCPDomainAllowed({ url: 'http://[2002:7f00:1::]/mcp' }, null)).toBe(false);
+      expect(await isMCPDomainAllowed({ url: 'ws://[2002:a9fe:a9fe::]/mcp' }, null)).toBe(false);
+    });
+
+    it('should block MCP server targeting NAT64 embedded private IPv4', async () => {
+      expect(await isMCPDomainAllowed({ url: 'http://[64:ff9b::127.0.0.1]/mcp' }, null)).toBe(
+        false,
+      );
+    });
+  });
+});
+
+describe('isOAuthUrlAllowed', () => {
+  it('should return false when allowedDomains is null/undefined/empty', () => {
+    expect(isOAuthUrlAllowed('https://example.com/token', null)).toBe(false);
+    expect(isOAuthUrlAllowed('https://example.com/token', undefined)).toBe(false);
+    expect(isOAuthUrlAllowed('https://example.com/token', [])).toBe(false);
+  });
+
+  it('should return false for unparseable URLs', () => {
+    expect(isOAuthUrlAllowed('not-a-url', ['example.com'])).toBe(false);
+  });
+
+  it('should match exact hostnames', () => {
+    expect(isOAuthUrlAllowed('https://example.com/token', ['example.com'])).toBe(true);
+    expect(isOAuthUrlAllowed('https://other.com/token', ['example.com'])).toBe(false);
+  });
+
+  it('should match wildcard subdomains', () => {
+    expect(isOAuthUrlAllowed('https://api.example.com/token', ['*.example.com'])).toBe(true);
+    expect(isOAuthUrlAllowed('https://deep.nested.example.com/token', ['*.example.com'])).toBe(
+      true,
+    );
+    expect(isOAuthUrlAllowed('https://example.com/token', ['*.example.com'])).toBe(true);
+    expect(isOAuthUrlAllowed('https://other.com/token', ['*.example.com'])).toBe(false);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(isOAuthUrlAllowed('https://EXAMPLE.COM/token', ['example.com'])).toBe(true);
+    expect(isOAuthUrlAllowed('https://example.com/token', ['EXAMPLE.COM'])).toBe(true);
+  });
+
+  it('should match private/internal URLs when hostname is in allowedDomains', () => {
+    expect(isOAuthUrlAllowed('http://localhost:8080/token', ['localhost'])).toBe(true);
+    expect(isOAuthUrlAllowed('http://10.0.0.1/token', ['10.0.0.1'])).toBe(true);
+    expect(
+      isOAuthUrlAllowed('http://host.docker.internal:8044/token', ['host.docker.internal']),
+    ).toBe(true);
+    expect(isOAuthUrlAllowed('http://myserver.local/token', ['*.local'])).toBe(true);
+  });
+
+  it('should match internal URLs with wildcard patterns', () => {
+    expect(isOAuthUrlAllowed('https://auth.company.internal/token', ['*.company.internal'])).toBe(
+      true,
+    );
+    expect(isOAuthUrlAllowed('https://company.internal/token', ['*.company.internal'])).toBe(true);
+  });
+
+  it('should not match when hostname is absent from allowedDomains', () => {
+    expect(isOAuthUrlAllowed('http://10.0.0.1/token', ['192.168.1.1'])).toBe(false);
+    expect(isOAuthUrlAllowed('http://localhost/token', ['host.docker.internal'])).toBe(false);
+  });
+
+  describe('protocol and port constraint enforcement', () => {
+    it('should enforce protocol when allowedDomains specifies one', () => {
+      expect(isOAuthUrlAllowed('https://auth.internal/token', ['https://auth.internal'])).toBe(
+        true,
+      );
+      expect(isOAuthUrlAllowed('http://auth.internal/token', ['https://auth.internal'])).toBe(
+        false,
+      );
+    });
+
+    it('should allow any protocol when allowedDomains has bare hostname', () => {
+      expect(isOAuthUrlAllowed('http://auth.internal/token', ['auth.internal'])).toBe(true);
+      expect(isOAuthUrlAllowed('https://auth.internal/token', ['auth.internal'])).toBe(true);
+    });
+
+    it('should enforce port when allowedDomains specifies one', () => {
+      expect(
+        isOAuthUrlAllowed('https://auth.internal:8443/token', ['https://auth.internal:8443']),
+      ).toBe(true);
+      expect(
+        isOAuthUrlAllowed('https://auth.internal:6379/token', ['https://auth.internal:8443']),
+      ).toBe(false);
+      expect(isOAuthUrlAllowed('https://auth.internal/token', ['https://auth.internal:8443'])).toBe(
+        false,
+      );
+    });
+
+    it('should allow any port when allowedDomains has no explicit port', () => {
+      expect(isOAuthUrlAllowed('https://auth.internal:8443/token', ['auth.internal'])).toBe(true);
+      expect(isOAuthUrlAllowed('https://auth.internal:22/token', ['auth.internal'])).toBe(true);
+    });
+
+    it('should reject wrong port even when hostname matches (prevents port-scanning)', () => {
+      expect(isOAuthUrlAllowed('http://10.0.0.1:6379/token', ['http://10.0.0.1:8080'])).toBe(false);
+      expect(isOAuthUrlAllowed('http://10.0.0.1:25/token', ['http://10.0.0.1:8080'])).toBe(false);
+    });
+  });
+});
+
+describe('validateEndpointURL', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw for unparseable URLs', async () => {
+    await expect(validateEndpointURL('not-a-url', 'test-ep')).rejects.toThrow(
+      'Invalid base URL for test-ep',
+    );
+  });
+
+  it('should throw for localhost URLs', async () => {
+    await expect(validateEndpointURL('http://localhost:8080/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for private IP URLs', async () => {
+    await expect(validateEndpointURL('http://192.168.1.1/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+    await expect(validateEndpointURL('http://10.0.0.1/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+    await expect(validateEndpointURL('http://172.16.0.1/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for link-local / metadata IP', async () => {
+    await expect(
+      validateEndpointURL('http://169.254.169.254/latest/meta-data/', 'test-ep'),
+    ).rejects.toThrow('targets a restricted address');
+  });
+
+  it('should throw for loopback IP', async () => {
+    await expect(validateEndpointURL('http://127.0.0.1:11434/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for internal Docker/Kubernetes hostnames', async () => {
+    await expect(validateEndpointURL('http://redis:6379/', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+    await expect(validateEndpointURL('http://mongodb:27017/', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw when hostname DNS-resolves to a private IP', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }] as never);
+    await expect(validateEndpointURL('https://evil.example.com/v1', 'test-ep')).rejects.toThrow(
+      'resolves to a restricted address',
+    );
+  });
+
+  it('should allow public URLs', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '104.18.7.192', family: 4 }] as never);
+    await expect(
+      validateEndpointURL('https://api.openai.com/v1', 'test-ep'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should allow public URLs that resolve to public IPs', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '8.8.8.8', family: 4 }] as never);
+    await expect(
+      validateEndpointURL('https://api.example.com/v1/chat', 'test-ep'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should throw for non-HTTP/HTTPS schemes', async () => {
+    await expect(validateEndpointURL('ftp://example.com/v1', 'test-ep')).rejects.toThrow(
+      'only HTTP and HTTPS are permitted',
+    );
+    await expect(validateEndpointURL('file:///etc/passwd', 'test-ep')).rejects.toThrow(
+      'only HTTP and HTTPS are permitted',
+    );
+    await expect(validateEndpointURL('data:text/plain,hello', 'test-ep')).rejects.toThrow(
+      'only HTTP and HTTPS are permitted',
+    );
+  });
+
+  it('should throw for IPv6 loopback URL', async () => {
+    await expect(validateEndpointURL('http://[::1]:8080/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for IPv6 link-local URL', async () => {
+    await expect(validateEndpointURL('http://[fe80::1]/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for IPv6 unique-local URL', async () => {
+    await expect(validateEndpointURL('http://[fc00::1]/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for .local TLD hostname', async () => {
+    await expect(validateEndpointURL('http://myservice.local/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for .internal TLD hostname', async () => {
+    await expect(validateEndpointURL('http://api.internal/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should pass when DNS lookup fails (fail-open)', async () => {
+    mockedLookup.mockRejectedValueOnce(new Error('ENOTFOUND'));
+    await expect(
+      validateEndpointURL('https://nonexistent.example.com/v1', 'test-ep'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should throw structured JSON with type invalid_base_url', async () => {
+    const error = await validateEndpointURL('http://169.254.169.254/latest/', 'my-ep').catch(
+      (err: Error) => err,
+    );
+    expect(error).toBeInstanceOf(Error);
+    const parsed = JSON.parse((error as Error).message);
+    expect(parsed.type).toBe('invalid_base_url');
+    expect(parsed.message).toContain('my-ep');
+    expect(parsed.message).toContain('targets a restricted address');
+  });
+});
+
+describe('isAddressAllowed', () => {
+  it('returns false when no allowedAddresses configured', () => {
+    expect(isAddressAllowed('127.0.0.1')).toBe(false);
+    expect(isAddressAllowed('127.0.0.1', null)).toBe(false);
+    expect(isAddressAllowed('127.0.0.1', [])).toBe(false);
+  });
+
+  it('matches literal IPv4 entries', () => {
+    expect(isAddressAllowed('127.0.0.1', ['127.0.0.1:11434'], '11434')).toBe(true);
+    expect(isAddressAllowed('10.0.0.5', ['127.0.0.1:11434', '10.0.0.5:8080'], 8080)).toBe(true);
+    expect(isAddressAllowed('192.168.1.1', ['10.0.0.5:8080'], '8080')).toBe(false);
+  });
+
+  it('matches literal hostnames case-insensitively', () => {
+    expect(isAddressAllowed('localhost', ['localhost:11434'], '11434')).toBe(true);
+    expect(isAddressAllowed('LOCALHOST', ['localhost:11434'], '11434')).toBe(true);
+    expect(isAddressAllowed('host.docker.internal', ['HOST.DOCKER.INTERNAL:8080'], 8080)).toBe(
+      true,
+    );
+  });
+
+  it('strips IPv6 brackets when matching', () => {
+    expect(isAddressAllowed('[::1]', ['[::1]:11434'], '11434')).toBe(true);
+    expect(isAddressAllowed('::1', ['[::1]:11434'], '11434')).toBe(true);
+  });
+
+  it('does not match a different port on the same address', () => {
+    expect(isAddressAllowed('localhost', ['localhost:11434'], '8080')).toBe(false);
+    expect(isAddressAllowed('127.0.0.1', ['127.0.0.1:11434'], '8080')).toBe(false);
+  });
+
+  it('does not match bare allowedAddresses entries', () => {
+    expect(isAddressAllowed('localhost', ['localhost'], '11434')).toBe(false);
+    expect(isAddressAllowed('127.0.0.1', ['127.0.0.1'], '11434')).toBe(false);
+  });
+
+  it('does not partial-match hostnames', () => {
+    expect(isAddressAllowed('evil.localhost', ['localhost:11434'], '11434')).toBe(false);
+    expect(isAddressAllowed('host', ['host.docker.internal:11434'], '11434')).toBe(false);
+  });
+
+  it('ignores empty entries', () => {
+    expect(isAddressAllowed('localhost', ['', '   ', 'localhost:11434'], '11434')).toBe(true);
+    expect(isAddressAllowed('localhost', ['', '   '], '11434')).toBe(false);
+  });
+});
+
+describe('SSRF allowedAddresses exemption', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isSSRFTarget', () => {
+    it('exempts a hostname listed in allowedAddresses', () => {
+      expect(isSSRFTarget('localhost')).toBe(true);
+      expect(isSSRFTarget('localhost', ['localhost:11434'], '11434')).toBe(false);
+    });
+
+    it('exempts a private IP listed in allowedAddresses', () => {
+      expect(isSSRFTarget('10.0.0.5')).toBe(true);
+      expect(isSSRFTarget('10.0.0.5', ['10.0.0.5:11434'], '11434')).toBe(false);
+    });
+
+    it('does not exempt a different port on an allowed private target', () => {
+      expect(isSSRFTarget('localhost', ['localhost:11434'], '22')).toBe(true);
+      expect(isSSRFTarget('10.0.0.5', ['10.0.0.5:11434'], '22')).toBe(true);
+    });
+
+    it('does not exempt an unlisted private target', () => {
+      expect(isSSRFTarget('192.168.1.1', ['10.0.0.5:11434'], '11434')).toBe(true);
+    });
+
+    it('leaves public destinations unaffected when allowedAddresses is set', () => {
+      expect(isSSRFTarget('api.openai.com', ['localhost:11434'], '11434')).toBe(false);
+    });
+  });
+
+  describe('resolveHostnameSSRF', () => {
+    it('exempts when the hostname itself matches allowedAddresses', async () => {
+      // No lookup mock needed: a hostname-literal match short-circuits before DNS.
+      expect(await resolveHostnameSSRF('ollama.internal', ['ollama.internal:11434'], '11434')).toBe(
+        false,
+      );
+    });
+
+    it('exempts when a resolved IP matches allowedAddresses', async () => {
+      mockedLookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }] as never);
+      expect(await resolveHostnameSSRF('private.example.com', ['10.0.0.5:11434'], '11434')).toBe(
+        false,
+      );
+    });
+
+    it('blocks when the host matches but the port does not', async () => {
+      mockedLookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }] as never);
+      expect(await resolveHostnameSSRF('private.example.com', ['10.0.0.5:11434'], '22')).toBe(true);
+    });
+
+    it('still blocks when no entry matches', async () => {
+      mockedLookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }] as never);
+      expect(await resolveHostnameSSRF('private.example.com', ['127.0.0.1:11434'], '11434')).toBe(
+        true,
+      );
+    });
+
+    it('blocks when one of multiple resolved IPs is private and unlisted', async () => {
+      mockedLookup.mockResolvedValueOnce([
+        { address: '8.8.8.8', family: 4 },
+        { address: '10.0.0.5', family: 4 },
+      ] as never);
+      expect(await resolveHostnameSSRF('mixed.example.com', ['127.0.0.1:11434'], '11434')).toBe(
+        true,
+      );
+    });
+
+    it('passes when all resolved private IPs are listed', async () => {
+      mockedLookup.mockResolvedValueOnce([
+        { address: '10.0.0.5', family: 4 },
+        { address: '10.0.0.6', family: 4 },
+      ] as never);
+      expect(
+        await resolveHostnameSSRF(
+          'cluster.example.com',
+          ['10.0.0.5:11434', '10.0.0.6:11434'],
+          '11434',
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('validateEndpointURL', () => {
+    it('passes a private-IP URL when its IP is in allowedAddresses', async () => {
+      await expect(
+        validateEndpointURL('http://10.0.0.5/v1', 'ollama', ['10.0.0.5:80']),
+      ).resolves.toBeUndefined();
+    });
+
+    it('passes a localhost URL when localhost is in allowedAddresses', async () => {
+      await expect(
+        validateEndpointURL('http://localhost:11434/v1', 'ollama', ['localhost:11434']),
+      ).resolves.toBeUndefined();
+    });
+
+    it('passes a hostname URL when DNS resolves to an exempted IP', async () => {
+      mockedLookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }] as never);
+      await expect(
+        validateEndpointURL('https://ollama.example.com/v1', 'ollama', ['10.0.0.5:443']),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects a different port on the same allowed private address', async () => {
+      await expect(
+        validateEndpointURL('http://localhost:22/v1', 'ollama', ['localhost:11434']),
+      ).rejects.toThrow('targets a restricted address');
+    });
+
+    it('still rejects unlisted private IPs when allowedAddresses is set', async () => {
+      await expect(
+        validateEndpointURL('http://192.168.1.1/v1', 'test-ep', ['10.0.0.5:80']),
+      ).rejects.toThrow('targets a restricted address');
+    });
+
+    it('still rejects non-http schemes regardless of allowedAddresses', async () => {
+      await expect(
+        validateEndpointURL('file:///etc/passwd', 'test-ep', ['localhost:11434']),
+      ).rejects.toThrow('only HTTP and HTTPS are permitted');
+    });
+  });
+
+  describe('isActionDomainAllowed', () => {
+    it('exempts a private IP when listed in allowedAddresses (no allowedDomains)', async () => {
+      expect(await isActionDomainAllowed('http://10.0.0.5:8080/api', null, ['10.0.0.5:8080'])).toBe(
+        true,
+      );
+    });
+
+    it('does not exempt a different port on an allowed private IP', async () => {
+      expect(await isActionDomainAllowed('http://10.0.0.5:8081/api', null, ['10.0.0.5:8080'])).toBe(
+        false,
+      );
+    });
+
+    it('still blocks unlisted private IPs', async () => {
+      expect(await isActionDomainAllowed('http://192.168.1.1/api', null, ['10.0.0.5:80'])).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('isMCPDomainAllowed', () => {
+    it('exempts a private-IP MCP server when its IP is in allowedAddresses', async () => {
+      expect(
+        await isMCPDomainAllowed({ url: 'https://10.0.0.5:8443/mcp' }, null, ['10.0.0.5:8443']),
+      ).toBe(true);
+    });
+
+    it('still blocks an unlisted private MCP target', async () => {
+      expect(
+        await isMCPDomainAllowed({ url: 'https://192.168.1.1/mcp' }, null, ['10.0.0.5:443']),
+      ).toBe(false);
+    });
+  });
+
+  describe('isOAuthUrlAllowed', () => {
+    it('returns true when the URL host:port is in allowedAddresses (no allowedDomains)', () => {
+      expect(isOAuthUrlAllowed('https://10.0.0.5/oauth', null, ['10.0.0.5:443'])).toBe(true);
+    });
+
+    it('returns false when the OAuth URL uses a different port than allowedAddresses', () => {
+      expect(isOAuthUrlAllowed('https://10.0.0.5:8443/oauth', null, ['10.0.0.5:443'])).toBe(false);
+    });
+
+    it('still requires allowedDomains match for non-exempted URLs', () => {
+      expect(isOAuthUrlAllowed('https://other.example.com/oauth', null, ['10.0.0.5:443'])).toBe(
+        false,
+      );
+      expect(
+        isOAuthUrlAllowed(
+          'https://other.example.com/oauth',
+          ['other.example.com'],
+          ['10.0.0.5:443'],
+        ),
+      ).toBe(true);
+    });
+
+    it('does not let allowedAddresses bypass a configured allowedDomains list', () => {
+      // Admin set `mcpSettings.allowedDomains` to constrain OAuth metadata/token/revocation
+      // hosts. An unrelated `allowedAddresses` entry (e.g. for self-hosted Ollama) must NOT
+      // broaden that bound — otherwise a malicious MCP server could advertise OAuth at any
+      // exempted private address and pass validation.
+      expect(
+        isOAuthUrlAllowed('http://10.0.0.5/oauth', ['oauth.trusted.com'], ['10.0.0.5:80']),
+      ).toBe(false);
+      expect(
+        isOAuthUrlAllowed('http://127.0.0.1/oauth', ['oauth.trusted.com'], ['127.0.0.1:80']),
+      ).toBe(false);
+    });
+
+    it('rejects schemeless inputs even when the host:port is in allowedAddresses', () => {
+      // `parseDomainSpec` quietly prepends `https://` to schemeless inputs.
+      // Without a strict `new URL(url)` gate, a value like `10.0.0.5/oauth`
+      // would short-circuit the trust-bypass and skip `validateOAuthUrl`'s
+      // own parse-or-throw. The check must require an absolute URL.
+      expect(isOAuthUrlAllowed('10.0.0.5/oauth', null, ['10.0.0.5:443'])).toBe(false);
+      expect(isOAuthUrlAllowed('127.0.0.1', null, ['127.0.0.1:443'])).toBe(false);
+      expect(isOAuthUrlAllowed('//10.0.0.5/oauth', null, ['10.0.0.5:443'])).toBe(false);
     });
   });
 });

--- a/packages/api/src/auth/domain.ts
+++ b/packages/api/src/auth/domain.ts
@@ -1,4 +1,13 @@
 import { lookup } from 'node:dns/promises';
+import {
+  normalizePort,
+  isAddressInAllowedSet,
+  normalizeAllowedAddressesSet,
+} from './allowedAddresses';
+import { isPrivateIP } from './ip';
+
+/** Re-exported here for backward compatibility; canonical location is `./ip`. */
+export { isPrivateIP };
 
 /**
  * @param email
@@ -24,83 +33,61 @@ export function isEmailDomainAllowed(email: string, allowedDomains?: string[] | 
   return allowedDomains.some((allowedDomain) => allowedDomain?.toLowerCase() === domain);
 }
 
-/** Checks if IPv4 octets fall within private, reserved, or link-local ranges */
-function isPrivateIPv4(a: number, b: number, c: number): boolean {
-  if (a === 127) {
-    return true;
-  }
-  if (a === 10) {
-    return true;
-  }
-  if (a === 172 && b >= 16 && b <= 31) {
-    return true;
-  }
-  if (a === 192 && b === 168) {
-    return true;
-  }
-  if (a === 169 && b === 254) {
-    return true;
-  }
-  if (a === 0 && b === 0 && c === 0) {
-    return true;
-  }
-  return false;
+/**
+ * Checks whether a hostname/IP literal and port appear in an admin-supplied
+ * exemption list. Address match is case-insensitive and bracket-stripped, so
+ * `[::1]` matches `::1` and `LOCALHOST` matches `localhost` when the port
+ * also matches.
+ *
+ * The normalization and scoping rules live in `./allowedAddresses` so the
+ * connect-time DNS lookup in `agent.ts` and this preflight helper share a
+ * single implementation. See that module for the security invariants.
+ */
+export function isAddressAllowed(
+  hostnameOrIP: string,
+  allowedAddresses?: string[] | null,
+  port?: string | number | null,
+): boolean {
+  const set = normalizeAllowedAddressesSet(allowedAddresses);
+  return isAddressInAllowedSet(hostnameOrIP, set, port);
 }
 
 /**
- * Checks if an IP address belongs to a private, reserved, or link-local range.
- * Handles IPv4, IPv6, and IPv4-mapped IPv6 addresses (::ffff:A.B.C.D).
+ * Checks if a hostname resolves to a private/reserved IP address.
+ * Directly validates literal IPv4 and IPv6 addresses without DNS lookup.
+ * For hostnames, resolves via DNS and checks all returned addresses.
+ * Fails open on DNS errors (returns false), since the HTTP request would also fail.
+ *
+ * When `allowedAddresses` is provided, the hostname/port and any resolved
+ * IP/port are matched against the list — a match short-circuits to `false`
+ * so admin-exempted private services bypass the SSRF block.
  */
-export function isPrivateIP(ip: string): boolean {
-  const normalized = ip.toLowerCase().trim();
-
-  const mappedMatch = normalized.match(/^::ffff:(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (mappedMatch) {
-    const [, a, b, c] = mappedMatch.map(Number);
-    return isPrivateIPv4(a, b, c);
-  }
-
-  const ipv4Match = normalized.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4Match) {
-    const [, a, b, c] = ipv4Match.map(Number);
-    return isPrivateIPv4(a, b, c);
-  }
-
-  const ipv6 = normalized.replace(/^\[|\]$/g, '');
-  if (
-    ipv6 === '::1' ||
-    ipv6 === '::' ||
-    ipv6.startsWith('fc') ||
-    ipv6.startsWith('fd') ||
-    ipv6.startsWith('fe80')
-  ) {
-    return true;
-  }
-
-  return false;
-}
-
-/**
- * Resolves a hostname via DNS and checks if any resolved address is a private/reserved IP.
- * Detects DNS-based SSRF bypasses (e.g., nip.io wildcard DNS, attacker-controlled nameservers).
- * Fails open: returns false if DNS resolution fails, since hostname-only checks still apply
- * and the actual HTTP request would also fail.
- */
-export async function resolveHostnameSSRF(hostname: string): Promise<boolean> {
+export async function resolveHostnameSSRF(
+  hostname: string,
+  allowedAddresses?: string[] | null,
+  port?: string | number | null,
+): Promise<boolean> {
   const normalizedHost = hostname.toLowerCase().trim();
 
-  if (/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.test(normalizedHost)) {
+  if (isAddressAllowed(normalizedHost, allowedAddresses, port)) {
     return false;
+  }
+
+  if (/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.test(normalizedHost)) {
+    return isPrivateIP(normalizedHost);
   }
 
   const ipv6Check = normalizedHost.replace(/^\[|\]$/g, '');
   if (ipv6Check.includes(':')) {
-    return false;
+    return isPrivateIP(ipv6Check);
   }
 
   try {
     const addresses = await lookup(hostname, { all: true });
-    return addresses.some((entry) => isPrivateIP(entry.address));
+    return addresses.some(
+      (entry) =>
+        isPrivateIP(entry.address) && !isAddressAllowed(entry.address, allowedAddresses, port),
+    );
   } catch {
     return false;
   }
@@ -109,11 +96,26 @@ export async function resolveHostnameSSRF(hostname: string): Promise<boolean> {
 /**
  * SSRF Protection: Checks if a hostname/IP is a potentially dangerous internal target.
  * Blocks private IPs, localhost, cloud metadata IPs, and common internal hostnames.
+ *
+ * When `allowedAddresses` is provided, a literal host:port match exempts the
+ * target — used by admins to permit known-good internal services (self-hosted
+ * Ollama, Docker host, etc.) without disabling SSRF protection for every port
+ * on the same host.
+ *
  * @param hostname - The hostname or IP to check
+ * @param allowedAddresses - Optional admin exemption list of host:port pairs
  * @returns true if the target is blocked (SSRF risk), false if safe
  */
-export function isSSRFTarget(hostname: string): boolean {
+export function isSSRFTarget(
+  hostname: string,
+  allowedAddresses?: string[] | null,
+  port?: string | number | null,
+): boolean {
   const normalizedHost = hostname.toLowerCase().trim();
+
+  if (isAddressAllowed(normalizedHost, allowedAddresses, port)) {
+    return false;
+  }
 
   if (
     normalizedHost === 'localhost' ||
@@ -268,17 +270,33 @@ function hostnameMatches(inputHostname: string, allowedSpec: ParsedDomainSpec): 
 const HTTP_PROTOCOLS: SupportedProtocol[] = ['http:', 'https:'];
 const MCP_PROTOCOLS: SupportedProtocol[] = ['http:', 'https:', 'ws:', 'wss:'];
 
+function defaultPortForProtocol(protocol: SupportedProtocol | string | null): string {
+  if (protocol === 'http:' || protocol === 'ws:') return '80';
+  if (protocol === 'https:' || protocol === 'wss:') return '443';
+  return '';
+}
+
+function getEffectivePort(
+  protocol: SupportedProtocol | string | null,
+  port?: string | null,
+): string {
+  return normalizePort(port ? port : defaultPortForProtocol(protocol));
+}
+
 /**
  * Core domain validation logic with configurable protocol support.
  * SECURITY: When no allowedDomains is configured, blocks SSRF-prone targets.
  * @param domain - The domain to check (can include protocol/port)
  * @param allowedDomains - List of allowed domain patterns
  * @param supportedProtocols - Protocols to accept (others are rejected)
+ * @param allowedAddresses - Optional admin exemption list of host:port pairs
+ *   that bypass the private-IP block when no allowedDomains whitelist is active
  */
 async function isDomainAllowedCore(
   domain: string,
   allowedDomains: string[] | null | undefined,
   supportedProtocols: SupportedProtocol[],
+  allowedAddresses?: string[] | null,
 ): Promise<boolean> {
   const inputSpec = parseDomainSpec(domain);
   if (!inputSpec) {
@@ -292,12 +310,13 @@ async function isDomainAllowedCore(
 
   /** If no domain restrictions configured, block SSRF targets but allow all else */
   if (!Array.isArray(allowedDomains) || !allowedDomains.length) {
+    const effectivePort = getEffectivePort(inputSpec.protocol, inputSpec.port);
     /** SECURITY: Block SSRF-prone targets when no allowlist is configured */
-    if (isSSRFTarget(inputSpec.hostname)) {
+    if (isSSRFTarget(inputSpec.hostname, allowedAddresses, effectivePort)) {
       return false;
     }
     /** SECURITY: Resolve hostname and block if it points to a private/reserved IP */
-    if (await resolveHostnameSSRF(inputSpec.hostname)) {
+    if (await resolveHostnameSSRF(inputSpec.hostname, allowedAddresses, effectivePort)) {
       return false;
     }
     return true;
@@ -348,21 +367,26 @@ async function isDomainAllowedCore(
  * SECURITY: WebSocket protocols are NOT allowed per OpenAPI specification.
  * @param domain - The domain to check (can include protocol/port)
  * @param allowedDomains - List of allowed domain patterns
+ * @param allowedAddresses - Optional admin exemption list of host:port pairs
  */
 export async function isActionDomainAllowed(
   domain?: string | null,
   allowedDomains?: string[] | null,
+  allowedAddresses?: string[] | null,
 ): Promise<boolean> {
   if (!domain || typeof domain !== 'string') {
     return false;
   }
-  return isDomainAllowedCore(domain, allowedDomains, HTTP_PROTOCOLS);
+  return isDomainAllowedCore(domain, allowedDomains, HTTP_PROTOCOLS, allowedAddresses);
 }
 
 /**
  * Extracts full domain spec (protocol://hostname:port) from MCP server config URL.
  * Returns the full origin for proper protocol/port matching against allowedDomains.
- * Returns null for stdio transports (no URL) or invalid URLs.
+ * @returns The full origin string, or null when:
+ *   - No `url` property, non-string, or empty (stdio transport — always allowed upstream)
+ *   - URL string present but cannot be parsed (rejected fail-closed upstream when allowlist active)
+ *   Callers must distinguish these two null cases; see {@link isMCPDomainAllowed}.
  * @param config - MCP server configuration (accepts any config with optional url field)
  */
 export function extractMCPServerDomain(config: Record<string, unknown>): string | null {
@@ -386,20 +410,169 @@ export function extractMCPServerDomain(config: Record<string, unknown>): string 
  * Validates MCP server domain against allowedDomains.
  * Supports HTTP, HTTPS, WS, and WSS protocols (per MCP specification).
  * Stdio transports (no URL) are always allowed.
+ * Configs with a non-empty URL that cannot be parsed are rejected fail-closed when an
+ * allowlist is active, preventing template placeholders (e.g. `{{HOST}}`) from bypassing
+ * domain validation after `processMCPEnv` resolves them at connection time.
+ * When no allowlist is configured, unparseable URLs fall through to connection-level
+ * SSRF protection (`createSSRFSafeUndiciConnect`).
  * @param config - MCP server configuration with optional url field
  * @param allowedDomains - List of allowed domains (with wildcard support)
  */
 export async function isMCPDomainAllowed(
   config: Record<string, unknown>,
   allowedDomains?: string[] | null,
+  allowedAddresses?: string[] | null,
 ): Promise<boolean> {
   const domain = extractMCPServerDomain(config);
+  const hasAllowlist = Array.isArray(allowedDomains) && allowedDomains.length > 0;
 
-  // Stdio transports don't have domains - always allowed
+  const hasExplicitUrl =
+    Object.prototype.hasOwnProperty.call(config, 'url') &&
+    typeof config.url === 'string' &&
+    config.url.trim().length > 0;
+
+  if (!domain && hasExplicitUrl && hasAllowlist) {
+    return false;
+  }
+
+  // Stdio transports (no URL) are always allowed
   if (!domain) {
     return true;
   }
 
   // Use MCP_PROTOCOLS (HTTP/HTTPS/WS/WSS) for MCP server validation
-  return isDomainAllowedCore(domain, allowedDomains, MCP_PROTOCOLS);
+  return isDomainAllowedCore(domain, allowedDomains, MCP_PROTOCOLS, allowedAddresses);
+}
+
+/**
+ * Checks whether an OAuth URL matches any entry in the MCP allowedDomains list,
+ * honoring protocol and port constraints when specified by the admin.
+ *
+ * Mirrors the allowlist-matching logic of {@link isDomainAllowedCore} (hostname,
+ * protocol, and explicit-port checks) but is synchronous — no DNS resolution is
+ * needed because the caller is deciding whether to *skip* the subsequent
+ * SSRF/DNS checks, not replace them.
+ *
+ * @remarks `parseDomainSpec` normalizes `www.` prefixes, so both the input URL
+ * and allowedDomains entries starting with `www.` are matched without that prefix.
+ */
+export function isOAuthUrlAllowed(
+  url: string,
+  allowedDomains?: string[] | null,
+  allowedAddresses?: string[] | null,
+): boolean {
+  /**
+   * Require an absolute URL with an explicit scheme. `parseDomainSpec` is
+   * lenient: it prepends `https://` to schemeless inputs so a value like
+   * `10.0.0.5/oauth` would otherwise short-circuit the trust-bypass via
+   * `allowedAddresses` and skip `validateOAuthUrl`'s strict `new URL(url)`
+   * parse-or-throw check, only to fail later in OAuth discovery with a less
+   * clear error. Falling through here lets the caller's strict parse run.
+   */
+  try {
+    new URL(url);
+  } catch {
+    return false;
+  }
+
+  const inputSpec = parseDomainSpec(url);
+  if (!inputSpec) {
+    return false;
+  }
+
+  /**
+   * When `allowedDomains` is configured, treat it as the authoritative bound
+   * on which OAuth URLs may bypass the SSRF/DNS check. `allowedAddresses` is
+   * an SSRF-private-IP exemption, not a domain allowlist — letting it
+   * short-circuit here would broaden a strict admin-configured OAuth scope
+   * (e.g. an MCP server could advertise OAuth endpoints at any address the
+   * admin permitted for an unrelated reason like a self-hosted LLM).
+   */
+  if (Array.isArray(allowedDomains) && allowedDomains.length > 0) {
+    for (const allowedDomain of allowedDomains) {
+      const allowedSpec = parseDomainSpec(allowedDomain);
+      if (!allowedSpec) {
+        continue;
+      }
+      if (!hostnameMatches(inputSpec.hostname, allowedSpec)) {
+        continue;
+      }
+      if (allowedSpec.protocol !== null) {
+        if (inputSpec.protocol === null || inputSpec.protocol !== allowedSpec.protocol) {
+          continue;
+        }
+      }
+      if (allowedSpec.explicitPort) {
+        if (!inputSpec.explicitPort || inputSpec.port !== allowedSpec.port) {
+          continue;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * No `allowedDomains` configured: the address exemption may permit specific
+   * private host:port pairs (matches the semantics of `validateOAuthUrl`'s
+   * downstream SSRF checks, which also consult `allowedAddresses`).
+   */
+  return isAddressAllowed(
+    inputSpec.hostname,
+    allowedAddresses,
+    getEffectivePort(inputSpec.protocol, inputSpec.port),
+  );
+}
+
+/** Matches ErrorTypes.INVALID_BASE_URL — string literal avoids build-time dependency on data-provider */
+const INVALID_BASE_URL_TYPE = 'invalid_base_url';
+
+function throwInvalidBaseURL(message: string): never {
+  throw new Error(JSON.stringify({ type: INVALID_BASE_URL_TYPE, message }));
+}
+
+/**
+ * Validates that a user-provided endpoint URL does not target private/internal addresses.
+ * Throws if the URL is unparseable, uses a non-HTTP(S) scheme, targets a known SSRF hostname,
+ * or DNS-resolves to a private IP.
+ *
+ * When `allowedAddresses` is provided, hostname/IP + port pairs are matched
+ * against the list — admin-exempted private services bypass the SSRF block.
+ * This lets operators permit known-good private services (self-hosted Ollama,
+ * Docker host, etc.) without disabling protection for every port on the same host.
+ *
+ * @note DNS rebinding: validation performs a single DNS lookup. An adversary controlling
+ *   DNS with TTL=0 could respond with a public IP at validation time and a private IP
+ *   at request time. This is an accepted limitation of point-in-time DNS checks.
+ * @note Fail-open on DNS errors: a resolution failure here implies a failure at request
+ *   time as well, matching {@link resolveHostnameSSRF} semantics.
+ */
+export async function validateEndpointURL(
+  url: string,
+  endpoint: string,
+  allowedAddresses?: string[] | null,
+): Promise<void> {
+  let hostname: string;
+  let protocol: string;
+  let port: string;
+  try {
+    const parsed = new URL(url);
+    hostname = parsed.hostname;
+    protocol = parsed.protocol;
+    port = getEffectivePort(protocol, parsed.port);
+  } catch {
+    throwInvalidBaseURL(`Invalid base URL for ${endpoint}: unable to parse URL.`);
+  }
+
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throwInvalidBaseURL(`Invalid base URL for ${endpoint}: only HTTP and HTTPS are permitted.`);
+  }
+
+  if (isSSRFTarget(hostname, allowedAddresses, port)) {
+    throwInvalidBaseURL(`Base URL for ${endpoint} targets a restricted address.`);
+  }
+
+  if (await resolveHostnameSSRF(hostname, allowedAddresses, port)) {
+    throwInvalidBaseURL(`Base URL for ${endpoint} resolves to a restricted address.`);
+  }
 }

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -1,6 +1,7 @@
+import { isIP } from 'node:net';
 import { EventEmitter } from 'events';
 import { logger } from '@librechat/data-schemas';
-import { fetch as undiciFetch, Agent } from 'undici';
+import { fetch as undiciFetch, Agent, ProxyAgent } from 'undici';
 import {
   StdioClientTransport,
   getDefaultEnvironment,
@@ -11,20 +12,42 @@ import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/webso
 import { ResourceListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type {
   RequestInit as UndiciRequestInit,
   RequestInfo as UndiciRequestInfo,
   Response as UndiciResponse,
+  Dispatcher,
 } from 'undici';
 import type { MCPOAuthTokens } from './oauth/types';
-import { withTimeout } from '~/utils/promise';
 import type * as t from './types';
 import { createSSRFSafeUndiciConnect, isSSRFTarget, resolveHostnameSSRF } from '~/auth';
+import { isAddressAllowed } from '~/auth/domain';
+import { runOutsideTracing } from '~/utils/tracing';
 import { sanitizeUrlForLogging } from './utils';
+import { withTimeout } from '~/utils/promise';
 import { mcpConfig } from './mcpConfig';
 
 type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+type ManagedDispatcher = Agent | ProxyAgent;
+type ParsedIP = { version: 4 | 6; bits: 32 | 128; value: bigint };
+
+const BIGINT_ZERO = BigInt(0);
+const BIGINT_ONE = BigInt(1);
+const BIGINT_EIGHT = BigInt(8);
+const BIGINT_SIXTEEN = BigInt(16);
+const UINT16_MASK = BigInt(0xffff);
+
+type MCPProxyConfig =
+  | {
+      type: 'explicit';
+      proxyUrl: string;
+    }
+  | {
+      type: 'env';
+      httpProxy?: string;
+      httpsProxy?: string;
+      noProxy?: string;
+    };
 
 function isStdioOptions(options: t.MCPOptions): options is t.StdioOptions {
   return 'command' in options;
@@ -71,18 +94,358 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 const DEFAULT_TIMEOUT = 60000;
 /** SSE connections through proxies may need longer initial handshake time */
 const SSE_CONNECT_TIMEOUT = 120000;
-
-/**
- * Maximum number of 307/308 (method-preserving) redirect hops an MCP request
- * will follow before giving up. Bounds redirect-chain amplification while still
- * supporting servers (e.g. Coda) that route doc-scoped tool calls via 308.
- */
+const DEFAULT_INIT_TIMEOUT = 30000;
+/** Max 307/308 redirects to follow per request (prevents redirect loops) */
 const MAX_REDIRECTS = 5;
+const DEFAULT_MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+const DEFAULT_MCP_STREAMABLE_HTTP_MAX_LINE_BYTES = 5 * 1024 * 1024;
+
+function getNonNegativeIntegerEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') {
+    return defaultValue;
+  }
+
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return defaultValue;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : defaultValue;
+}
+
+function bytesToMiB(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+function getMemoryDebugSnapshot(): Record<string, string> {
+  const mem = process.memoryUsage();
+  return {
+    rss: bytesToMiB(mem.rss),
+    heapUsed: bytesToMiB(mem.heapUsed),
+    heapTotal: bytesToMiB(mem.heapTotal),
+    external: bytesToMiB(mem.external),
+    arrayBuffers: bytesToMiB(mem.arrayBuffers ?? 0),
+  };
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+type JSONRPCRequestId = string | number;
+
+function getChunkBytes(chunk: unknown): Uint8Array {
+  if (typeof chunk === 'string') {
+    return textEncoder.encode(chunk);
+  }
+  if (chunk instanceof ArrayBuffer) {
+    return new Uint8Array(chunk);
+  }
+  if (ArrayBuffer.isView(chunk)) {
+    const view = new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+    return new Uint8Array(view);
+  }
+  return new Uint8Array();
+}
+
+function copyBytes(bytes: Uint8Array): Uint8Array {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy;
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  if (chunks.length === 0) {
+    return new Uint8Array();
+  }
+  if (chunks.length === 1) {
+    return chunks[0];
+  }
+  const totalLength = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return combined;
+}
+
+function getBodyText(body: unknown): string | null {
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (body instanceof ArrayBuffer) {
+    return textDecoder.decode(new Uint8Array(body));
+  }
+  if (ArrayBuffer.isView(body)) {
+    return textDecoder.decode(new Uint8Array(body.buffer, body.byteOffset, body.byteLength));
+  }
+  return null;
+}
+
+function getJSONRPCRequestIds(body: unknown): JSONRPCRequestId[] {
+  const bodyText = getBodyText(body);
+  if (!bodyText) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return [];
+  }
+
+  const messages = Array.isArray(parsed) ? parsed : [parsed];
+  return messages.flatMap((message) => {
+    if (!message || typeof message !== 'object') {
+      return [];
+    }
+    const jsonrpcMessage = message as { id?: unknown; method?: unknown };
+    const { id } = jsonrpcMessage;
+    if (typeof jsonrpcMessage.method !== 'string') {
+      return [];
+    }
+    if (typeof id !== 'string' && typeof id !== 'number') {
+      return [];
+    }
+    return [id];
+  });
+}
+
+function buildBlockedMCPResponseMessage(
+  reason: string,
+  details: {
+    maxResponseBytes: number;
+    maxLineBytes: number;
+    totalBytes: number;
+    currentLineBytes: number;
+    chunkCount: number;
+  },
+): string {
+  const limitDetails =
+    reason === 'MCP response exceeded byte limit'
+      ? `limit=${details.maxResponseBytes} bytes, observed=${details.totalBytes} bytes`
+      : `lineLimit=${details.maxLineBytes} bytes, observedLine=${details.currentLineBytes} bytes, observedTotal=${details.totalBytes} bytes`;
+
+  return `[MCP] ${reason} (${limitDetails}, chunks=${details.chunkCount}). The MCP server returned an unsafe streamable HTTP response; narrow the tool result or retry after the server response is fixed.`;
+}
+
+function buildBlockedMCPResponseSSE(requestIds: JSONRPCRequestId[], message: string): Uint8Array {
+  const events = requestIds
+    .map((id) => {
+      const payload = {
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32000,
+          message,
+        },
+      };
+      return `data: ${JSON.stringify(payload)}\n\n`;
+    })
+    .join('');
+  return textEncoder.encode(events);
+}
+
+function getMCPStreamableHTTPResponseLimits(): {
+  maxResponseBytes: number;
+  maxLineBytes: number;
+} {
+  return {
+    maxResponseBytes: getNonNegativeIntegerEnv(
+      'MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES',
+      DEFAULT_MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES,
+    ),
+    maxLineBytes: getNonNegativeIntegerEnv(
+      'MCP_STREAMABLE_HTTP_MAX_LINE_BYTES',
+      DEFAULT_MCP_STREAMABLE_HTTP_MAX_LINE_BYTES,
+    ),
+  };
+}
+
+async function guardMCPStreamableHTTPResponse(
+  response: UndiciResponse,
+  context: {
+    logPrefix: string;
+    method: string;
+    url: string;
+    requestIds?: JSONRPCRequestId[];
+  },
+): Promise<UndiciResponse> {
+  if (context.method === 'GET' || !response.body) {
+    return response;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const isEventStream = contentType.toLowerCase().includes('text/event-stream');
+  const { maxResponseBytes, maxLineBytes } = getMCPStreamableHTTPResponseLimits();
+  const canEmitFallbackSSEError = isEventStream && maxLineBytes > 0;
+  if (!isEventStream && maxResponseBytes === 0) {
+    return response;
+  }
+  if (maxResponseBytes === 0 && maxLineBytes === 0) {
+    return response;
+  }
+
+  let totalBytes = 0;
+  let currentLineBytes = 0;
+  let chunkCount = 0;
+  let pendingSSELineChunks: Uint8Array[] = [];
+  const sseEventDataLines: string[] = [];
+  const unresolvedRequestIds = new Set(context.requestIds ?? []);
+
+  const buildAndLogBlockedError = (reason: string, details: Record<string, unknown>): Error => {
+    const message = buildBlockedMCPResponseMessage(reason, {
+      maxResponseBytes,
+      maxLineBytes,
+      totalBytes,
+      currentLineBytes,
+      chunkCount,
+    });
+    logger.warn(`${context.logPrefix} MCP streamable HTTP response blocked: ${reason}`, {
+      method: context.method,
+      url: sanitizeUrlForLogging(context.url),
+      status: response.status,
+      contentType,
+      maxResponseBytes,
+      maxLineBytes,
+      totalBytes,
+      currentLineBytes,
+      chunkCount,
+      ...details,
+      memory: getMemoryDebugSnapshot(),
+    });
+    return new Error(message);
+  };
+
+  const trackSSELineForResolvedIds = (lineBytes: Uint8Array): void => {
+    if (unresolvedRequestIds.size === 0) {
+      return;
+    }
+
+    const rawLine = textDecoder.decode(lineBytes).replace(/[\r\n]+$/, '');
+    if (rawLine === '') {
+      if (sseEventDataLines.length === 0) {
+        return;
+      }
+      const data = sseEventDataLines.join('\n');
+      sseEventDataLines.length = 0;
+      try {
+        const parsed = JSON.parse(data) as { id?: unknown };
+        if (typeof parsed.id === 'string' || typeof parsed.id === 'number') {
+          unresolvedRequestIds.delete(parsed.id);
+        }
+      } catch {
+        /** Ignore malformed SSE data here; the SDK parser will report it. */
+      }
+      return;
+    }
+
+    const separatorIndex = rawLine.indexOf(':');
+    const field = separatorIndex === -1 ? rawLine : rawLine.slice(0, separatorIndex);
+    if (field !== 'data') {
+      return;
+    }
+    let value = separatorIndex === -1 ? '' : rawLine.slice(separatorIndex + 1);
+    if (value.startsWith(' ')) {
+      value = value.slice(1);
+    }
+    sseEventDataLines.push(value);
+  };
+
+  const enqueuePendingSSELine = (controller: TransformStreamDefaultController<Uint8Array>) => {
+    if (pendingSSELineChunks.length === 0) {
+      return;
+    }
+    const lineBytes = concatBytes(pendingSSELineChunks);
+    pendingSSELineChunks = [];
+    trackSSELineForResolvedIds(lineBytes);
+    controller.enqueue(lineBytes);
+  };
+
+  const blockResponse = (
+    controller: TransformStreamDefaultController<Uint8Array>,
+    reason: string,
+    details: Record<string, unknown>,
+  ) => {
+    const error = buildAndLogBlockedError(reason, details);
+    const fallbackRequestIds = [...unresolvedRequestIds];
+    if (canEmitFallbackSSEError && fallbackRequestIds.length > 0) {
+      controller.enqueue(buildBlockedMCPResponseSSE(fallbackRequestIds, error.message));
+      controller.terminate();
+      return;
+    }
+    throw error;
+  };
+
+  const guardedBody = (response.body as unknown as ReadableStream<unknown>).pipeThrough(
+    new TransformStream<unknown, Uint8Array>({
+      transform(chunk, controller) {
+        const bytes = getChunkBytes(chunk);
+        if (bytes.byteLength === 0) {
+          return;
+        }
+
+        chunkCount += 1;
+        totalBytes += bytes.byteLength;
+
+        if (maxResponseBytes > 0 && totalBytes > maxResponseBytes) {
+          blockResponse(controller, 'MCP response exceeded byte limit', {
+            chunkBytes: bytes.byteLength,
+          });
+          return;
+        }
+
+        if (isEventStream && maxLineBytes > 0) {
+          let segmentStart = 0;
+          for (let i = 0; i < bytes.byteLength; i++) {
+            const byte = bytes[i];
+            if (byte === 10 || byte === 13) {
+              if (i + 1 > segmentStart) {
+                pendingSSELineChunks.push(copyBytes(bytes.subarray(segmentStart, i + 1)));
+              }
+              enqueuePendingSSELine(controller);
+              segmentStart = i + 1;
+              currentLineBytes = 0;
+              continue;
+            }
+            currentLineBytes += 1;
+            if (currentLineBytes > maxLineBytes) {
+              blockResponse(controller, 'MCP response contained an oversized SSE line', {
+                chunkBytes: bytes.byteLength,
+              });
+              return;
+            }
+          }
+          if (segmentStart < bytes.byteLength) {
+            pendingSSELineChunks.push(copyBytes(bytes.subarray(segmentStart)));
+          }
+          return;
+        }
+
+        controller.enqueue(bytes);
+      },
+      flush(controller) {
+        enqueuePendingSSELine(controller);
+      },
+    }),
+  );
+
+  return new Response(guardedBody as unknown as BodyInit, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers as unknown as HeadersInit,
+  }) as unknown as UndiciResponse;
+}
 
 /**
- * Credential-bearing headers that must never survive a cross-origin redirect.
- * A server-controlled `Location` pointing at a different origin would otherwise
- * exfiltrate the caller's bearer token / session id to that origin.
+ * Headers stripped before forwarding a request across an origin boundary on
+ * 307/308 redirects, mirroring browser/Fetch-spec behavior. These headers can
+ * carry credentials (OAuth bearer, MCP session, cookies) that an attacker
+ * controlling a redirecting MCP endpoint could otherwise exfiltrate by sending
+ * a `Location` to a host they own.
  */
 const CROSS_ORIGIN_FORBIDDEN_HEADERS = new Set([
   'authorization',
@@ -91,26 +454,14 @@ const CROSS_ORIGIN_FORBIDDEN_HEADERS = new Set([
   'mcp-session-id',
 ]);
 
-/** Flattens undici/DOM header shapes to a plain lower-precedence record. */
-function normalizeInitHeaders(init: UndiciRequestInit | undefined): Record<string, string> {
-  if (!init?.headers) {
-    return {};
-  }
-  if (init.headers instanceof Headers) {
-    return Object.fromEntries(init.headers.entries());
-  }
-  if (Array.isArray(init.headers)) {
-    return Object.fromEntries(init.headers);
-  }
-  return init.headers as Record<string, string>;
-}
-
 /**
- * Normalizes a fetch `(input, init)` pair to `(urlString, init)` so the redirect
- * loop only ever deals with a string URL. When `input` is a `Request`, its
- * method, headers, and body are baked into the init and the body is buffered
- * (single-shot streams cannot be replayed on a 307/308 retry). Duck-typed rather
- * than `instanceof` because requests can cross undici realms.
+ * Normalizes a fetch input + init pair so the redirect loop only ever has
+ * to deal with `(string, init)`. When `input` is a `Request`, its method,
+ * headers, and body are baked into the returned init — explicit init values
+ * win (matching Fetch-spec semantics) and the body is buffered with
+ * `arrayBuffer()` so 307/308 retries can replay it on the new URL. Without
+ * this, switching `url` to a `Location` string on redirect would silently
+ * drop the original POST method and request payload.
  */
 async function resolveFetchInput(
   input: UndiciRequestInfo,
@@ -122,6 +473,15 @@ async function resolveFetchInput(
   if (input instanceof URL) {
     return { urlString: input.href, resolvedInit: init };
   }
+  /**
+   * Treat anything else as a `Request`. Duck-typed instead of
+   * `instanceof undici.Request` because requests handed to a generic fetch
+   * wrapper can come from a different undici realm and fail the prototype
+   * check while still implementing the same shape. The `as unknown as` cast
+   * is needed because undici's `Headers` and DOM's `Headers` have
+   * incompatible declared shapes even though they are interchangeable at
+   * runtime for the methods we use.
+   */
   const req = input as unknown as {
     url: string;
     method: string;
@@ -133,7 +493,14 @@ async function resolveFetchInput(
   const reqHeaders = Object.fromEntries(req.headers.entries());
   const initHeaders = normalizeInitHeaders(init);
   const mergedHeaders = { ...reqHeaders, ...initHeaders };
+  /** Body must be buffered before we hand it off — the original stream is
+   * single-shot, so a redirect retry with the same stream would crash with
+   * `body has been read`. Empty/no-body Requests skip the read entirely. */
   const reqBody = req.body ? await req.arrayBuffer() : undefined;
+  /** Forward the `Request`'s abort signal so callers that wired up an
+   * `AbortController` (for timeout / user-cancellation) keep working after
+   * we re-shape the input into `(string, init)`. Explicit `init.signal`
+   * still wins per Fetch-spec semantics. */
   const signal = init?.signal ?? req.signal ?? undefined;
   return {
     urlString: req.url,
@@ -147,27 +514,386 @@ async function resolveFetchInput(
   };
 }
 
-/**
- * Builds the undici init for one redirect hop. `redirect: 'manual'` is always
- * set so undici never auto-follows a redirect past our SSRF checks — every hop
- * is re-validated here instead.
- */
+function normalizeInitHeaders(init: UndiciRequestInit | undefined): Record<string, string> {
+  if (!init?.headers) {
+    return {};
+  }
+  if (init.headers instanceof Headers) {
+    return Object.fromEntries(init.headers.entries());
+  }
+  if (Array.isArray(init.headers)) {
+    return Object.fromEntries(init.headers);
+  }
+  return init.headers as Record<string, string>;
+}
+
 function buildFetchInit(
   init: UndiciRequestInit | undefined,
-  dispatcher: Agent,
+  dispatcher: Dispatcher,
   requestHeaders: Record<string, string> | null | undefined,
 ): UndiciRequestInit {
   const hasInitHeaders = init?.headers != null;
   const hasRuntimeHeaders = requestHeaders != null && Object.keys(requestHeaders).length > 0;
+  /**
+   * If neither `init.headers` nor runtime headers contribute anything, leave
+   * `headers` off the returned init entirely. Setting `headers: {}` would
+   * blow away the headers carried on a `Request` input — auth/session tokens
+   * and protocol negotiation headers — even when no redirect is involved.
+   */
   if (!hasInitHeaders && !hasRuntimeHeaders) {
     return { ...init, redirect: 'manual', dispatcher };
   }
   const initHeaders = normalizeInitHeaders(init);
   const headers = hasRuntimeHeaders ? { ...initHeaders, ...requestHeaders } : initHeaders;
-  return { ...init, redirect: 'manual', headers, dispatcher };
+  return {
+    ...init,
+    redirect: 'manual',
+    headers,
+    dispatcher,
+  };
 }
 
-/** Removes credential headers before a request crosses to a different origin. */
+function getUrlPort(url: URL | string): string {
+  const parsed = typeof url === 'string' ? new URL(url) : url;
+  if (parsed.port) return parsed.port;
+  if (parsed.protocol === 'http:' || parsed.protocol === 'ws:') return '80';
+  if (parsed.protocol === 'https:' || parsed.protocol === 'wss:') return '443';
+  return '';
+}
+
+function getTrimmedEnv(...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const rawValue = process.env[key];
+    if (rawValue != null) {
+      return rawValue.trim() || undefined;
+    }
+  }
+  return undefined;
+}
+
+function getMCPProxyConfig(options: t.MCPOptions): MCPProxyConfig | undefined {
+  const configuredProxy =
+    'proxy' in options && typeof options.proxy === 'string' ? options.proxy.trim() : '';
+  if (configuredProxy) {
+    return { type: 'explicit', proxyUrl: configuredProxy };
+  }
+
+  const libreChatProxy = process.env.PROXY?.trim() ?? '';
+  if (libreChatProxy) {
+    return { type: 'explicit', proxyUrl: libreChatProxy };
+  }
+
+  const httpProxy = getTrimmedEnv('http_proxy', 'HTTP_PROXY');
+  const httpsProxy = getTrimmedEnv('https_proxy', 'HTTPS_PROXY');
+  if (!httpProxy && !httpsProxy) {
+    return undefined;
+  }
+
+  return {
+    type: 'env',
+    httpProxy,
+    httpsProxy,
+    noProxy: getTrimmedEnv('no_proxy', 'NO_PROXY'),
+  };
+}
+
+function parseIPv4ToBigInt(ip: string): bigint | null {
+  const octets = ip.split('.');
+  if (octets.length !== 4) {
+    return null;
+  }
+
+  let value = BIGINT_ZERO;
+  for (const octet of octets) {
+    if (!/^\d{1,3}$/.test(octet)) {
+      return null;
+    }
+    const parsed = Number.parseInt(octet, 10);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 255) {
+      return null;
+    }
+    value = (value << BIGINT_EIGHT) + BigInt(parsed);
+  }
+  return value;
+}
+
+function parseIPv6ToBigInt(ip: string): bigint | null {
+  let normalized = ip.toLowerCase().replace(/^\[|\]$/g, '');
+  const zoneIndex = normalized.indexOf('%');
+  if (zoneIndex !== -1) {
+    normalized = normalized.slice(0, zoneIndex);
+  }
+
+  if (normalized.includes('.')) {
+    const lastColon = normalized.lastIndexOf(':');
+    if (lastColon === -1) {
+      return null;
+    }
+    const ipv4Value = parseIPv4ToBigInt(normalized.slice(lastColon + 1));
+    if (ipv4Value == null) {
+      return null;
+    }
+    const hi = Number((ipv4Value >> BIGINT_SIXTEEN) & UINT16_MASK).toString(16);
+    const lo = Number(ipv4Value & UINT16_MASK).toString(16);
+    normalized = `${normalized.slice(0, lastColon)}:${hi}:${lo}`;
+  }
+
+  const halves = normalized.split('::');
+  if (halves.length > 2) {
+    return null;
+  }
+
+  const left = halves[0] ? halves[0].split(':') : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const missing = halves.length === 2 ? 8 - left.length - right.length : 0;
+  if (missing < 0 || (halves.length === 1 && left.length !== 8)) {
+    return null;
+  }
+
+  const parts = [...left, ...Array<string>(missing).fill('0'), ...right];
+  if (parts.length !== 8 || parts.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) {
+    return null;
+  }
+
+  return parts.reduce(
+    (value, part) => (value << BIGINT_SIXTEEN) + BigInt(Number.parseInt(part, 16)),
+    BIGINT_ZERO,
+  );
+}
+
+function parseIPLiteral(value: string): ParsedIP | null {
+  const normalized = value
+    .toLowerCase()
+    .trim()
+    .replace(/^\[|\]$/g, '');
+  const version = isIP(normalized);
+  if (version === 4) {
+    const parsed = parseIPv4ToBigInt(normalized);
+    return parsed == null ? null : { version: 4, bits: 32, value: parsed };
+  }
+  if (version === 6) {
+    const parsed = parseIPv6ToBigInt(normalized);
+    return parsed == null ? null : { version: 6, bits: 128, value: parsed };
+  }
+  return null;
+}
+
+function ipMatchesCIDR(hostname: string, cidr: string): boolean {
+  const [rangeAddress, prefixLength, extra] = cidr.split('/');
+  if (!rangeAddress || prefixLength == null || extra != null || !/^\d+$/.test(prefixLength)) {
+    return false;
+  }
+
+  const hostIP = parseIPLiteral(hostname);
+  const rangeIP = parseIPLiteral(rangeAddress);
+  if (!hostIP || !rangeIP || hostIP.version !== rangeIP.version) {
+    return false;
+  }
+
+  const prefix = Number.parseInt(prefixLength, 10);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > rangeIP.bits) {
+    return false;
+  }
+
+  const bits = BigInt(rangeIP.bits);
+  const mask =
+    prefix === 0
+      ? BIGINT_ZERO
+      : (((BIGINT_ONE << bits) - BIGINT_ONE) << BigInt(rangeIP.bits - prefix)) &
+        ((BIGINT_ONE << bits) - BIGINT_ONE);
+  return (hostIP.value & mask) === (rangeIP.value & mask);
+}
+
+function ipMatchesRange(hostname: string, range: string): boolean {
+  const [startAddress, endAddress, extra] = range.split('-');
+  if (!startAddress || !endAddress || extra != null) {
+    return false;
+  }
+
+  const hostIP = parseIPLiteral(hostname);
+  const startIP = parseIPLiteral(startAddress);
+  const endIP = parseIPLiteral(endAddress);
+  if (
+    !hostIP ||
+    !startIP ||
+    !endIP ||
+    hostIP.version !== startIP.version ||
+    hostIP.version !== endIP.version
+  ) {
+    return false;
+  }
+
+  const min = startIP.value <= endIP.value ? startIP.value : endIP.value;
+  const max = startIP.value <= endIP.value ? endIP.value : startIP.value;
+  return hostIP.value >= min && hostIP.value <= max;
+}
+
+function matchesNoProxyIPPattern(hostname: string, entryHostname: string): boolean {
+  if (entryHostname.includes('/')) {
+    return ipMatchesCIDR(hostname, entryHostname);
+  }
+  if (entryHostname.includes('-')) {
+    return ipMatchesRange(hostname, entryHostname);
+  }
+  return false;
+}
+
+function getProxyEntryPort(entry: string): {
+  hostname: string;
+  port: number;
+} {
+  const trimmed = entry.trim();
+  const bracketed = trimmed.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (bracketed) {
+    return {
+      hostname: bracketed[1].toLowerCase(),
+      port: bracketed[2] ? Number.parseInt(bracketed[2], 10) : 0,
+    };
+  }
+
+  const separatorCount = (trimmed.match(/:/g) ?? []).length;
+  const parsed = separatorCount === 1 ? trimmed.match(/^(.+):(\d+)$/) : null;
+  const hostname = (parsed ? parsed[1] : trimmed).replace(/^\[|\]$/g, '').toLowerCase();
+  return {
+    hostname: hostname.replace(/^\*?\./, ''),
+    port: parsed ? Number.parseInt(parsed[2], 10) : 0,
+  };
+}
+
+function shouldBypassEnvProxy(url: URL, noProxy?: string): boolean {
+  if (!noProxy) {
+    return false;
+  }
+
+  const trimmed = noProxy.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed === '*') {
+    return true;
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  const port = Number.parseInt(getUrlPort(url), 10) || 0;
+
+  for (const entry of trimmed.split(/[,\s]/)) {
+    if (!entry) {
+      continue;
+    }
+    if (entry === '*') {
+      return true;
+    }
+
+    const proxyEntry = getProxyEntryPort(entry);
+    if (proxyEntry.port && proxyEntry.port !== port) {
+      continue;
+    }
+    if (matchesNoProxyIPPattern(hostname, proxyEntry.hostname)) {
+      return true;
+    }
+    if (hostname === proxyEntry.hostname || hostname.endsWith(`.${proxyEntry.hostname}`)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getProxyUrlForRequest(
+  proxyConfig: MCPProxyConfig | undefined,
+  urlString: string,
+): string | undefined {
+  if (!proxyConfig || !urlString) {
+    return undefined;
+  }
+  if (proxyConfig.type === 'explicit') {
+    return proxyConfig.proxyUrl;
+  }
+
+  const url = new URL(urlString);
+  if (shouldBypassEnvProxy(url, proxyConfig.noProxy)) {
+    return undefined;
+  }
+  if (url.protocol === 'https:') {
+    return proxyConfig.httpsProxy ?? proxyConfig.httpProxy;
+  }
+  if (url.protocol === 'http:') {
+    return proxyConfig.httpProxy;
+  }
+  return undefined;
+}
+
+function createMCPDispatcher(options: {
+  bodyTimeout: number;
+  headersTimeout: number;
+  proxyUrl?: string;
+  keepAliveTimeout?: number;
+  keepAliveMaxTimeout?: number;
+  connect?: ReturnType<typeof createSSRFSafeUndiciConnect>;
+}): ManagedDispatcher {
+  const { bodyTimeout, headersTimeout, proxyUrl, keepAliveTimeout, keepAliveMaxTimeout, connect } =
+    options;
+
+  const baseOptions = {
+    bodyTimeout,
+    headersTimeout,
+    ...(keepAliveTimeout != null ? { keepAliveTimeout } : {}),
+    ...(keepAliveMaxTimeout != null ? { keepAliveMaxTimeout } : {}),
+  };
+
+  if (proxyUrl) {
+    return new ProxyAgent({
+      uri: proxyUrl,
+      ...baseOptions,
+    });
+  }
+
+  return new Agent({
+    ...baseOptions,
+    ...(connect != null ? { connect } : {}),
+  });
+}
+
+async function assertProxiedRequestTargetAllowed(
+  urlString: string,
+  proxyConfig: MCPProxyConfig | undefined,
+  useSSRFProtection: boolean,
+  allowedAddresses?: string[] | null,
+): Promise<void> {
+  const proxyUrl = getProxyUrlForRequest(proxyConfig, urlString);
+  if (!proxyUrl || !useSSRFProtection) {
+    return;
+  }
+
+  const targetUrl = new URL(urlString);
+  const port = getUrlPort(targetUrl);
+  if (isAddressAllowed(targetUrl.hostname, allowedAddresses, port)) {
+    return;
+  }
+  if (!parseIPLiteral(targetUrl.hostname)) {
+    throw new Error(
+      `SSRF protection: proxied MCP request target "${targetUrl.hostname}" must be an IP literal or an explicitly allowed host`,
+    );
+  }
+
+  const isBlockedTarget =
+    isSSRFTarget(targetUrl.hostname, allowedAddresses, port) ||
+    (await resolveHostnameSSRF(targetUrl.hostname, allowedAddresses, port));
+
+  if (!isBlockedTarget) {
+    return;
+  }
+
+  throw new Error(
+    `SSRF protection: proxied MCP request target "${targetUrl.hostname}" resolved to a private/reserved address`,
+  );
+}
+
+/**
+ * Drops credential-bearing headers when a 307/308 redirect crosses an origin
+ * boundary. Removes the always-forbidden set plus any caller-supplied secret
+ * headers (runtime `setRequestHeaders` values and config-level API keys).
+ */
 function stripCrossOriginHeaders(
   headers: Record<string, string>,
   secretHeaderKeys: ReadonlySet<string>,
@@ -175,13 +901,37 @@ function stripCrossOriginHeaders(
   const stripped: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
     const lowered = key.toLowerCase();
-    if (CROSS_ORIGIN_FORBIDDEN_HEADERS.has(lowered) || secretHeaderKeys.has(lowered)) {
+    if (CROSS_ORIGIN_FORBIDDEN_HEADERS.has(lowered)) {
+      continue;
+    }
+    if (secretHeaderKeys.has(lowered)) {
       continue;
     }
     stripped[key] = value;
   }
   return stripped;
 }
+
+interface CircuitBreakerState {
+  cycleCount: number;
+  cycleWindowStart: number;
+  cooldownUntil: number;
+  failedRounds: number;
+  failedWindowStart: number;
+  failedBackoffUntil: number;
+}
+
+/** Default body timeout for Streamable HTTP GET SSE streams that idle between server pushes */
+const DEFAULT_SSE_READ_TIMEOUT = FIVE_MINUTES;
+
+/**
+ * Error message prefixes emitted by the MCP SDK's StreamableHTTPClientTransport
+ * (client/streamableHttp.ts → _handleSseStream / _scheduleReconnection).
+ * These are SDK-internal strings, not part of a public API. If the SDK changes
+ * them, suppression in setupTransportErrorHandlers will silently stop working.
+ */
+const SDK_SSE_STREAM_DISCONNECTED = 'SSE stream disconnected';
+const SDK_SSE_RECONNECT_FAILED = 'Failed to reconnect SSE stream';
 
 /**
  * Headers for SSE connections.
@@ -312,6 +1062,21 @@ function extractSSEErrorMessage(error: unknown): {
     };
   }
 
+  /**
+   * "fetch failed" is a generic undici TypeError that occurs when an in-flight HTTP request
+   * is aborted (e.g. after an MCP protocol-level timeout fires). The transport itself is still
+   * functional — only the individual request was lost — so treat this as transient.
+   */
+  if (rawMessage === 'fetch failed') {
+    return {
+      message:
+        'fetch failed (request aborted, likely after a timeout — connection may still be usable)',
+      code,
+      isProxyHint: false,
+      isTransient: true,
+    };
+  }
+
   return {
     message: rawMessage,
     code,
@@ -326,6 +1091,7 @@ interface MCPConnectionParams {
   userId?: string;
   oauthTokens?: MCPOAuthTokens | null;
   useSSRFProtection?: boolean;
+  allowedAddresses?: string[] | null;
 }
 
 export class MCPConnection extends EventEmitter {
@@ -340,15 +1106,20 @@ export class MCPConnection extends EventEmitter {
   private isReconnecting = false;
   private isInitializing = false;
   private reconnectAttempts = 0;
+  private agents: Dispatcher[] = [];
   private readonly userId?: string;
   private lastPingTime: number;
   private lastConnectionCheckAt: number = 0;
   private oauthTokens?: MCPOAuthTokens | null;
   private requestHeaders?: Record<string, string> | null;
   private oauthRequired = false;
+  private oauthRecovery = false;
   private readonly useSSRFProtection: boolean;
+  private readonly allowedAddresses?: string[] | null;
+  private readonly proxyConfig?: MCPProxyConfig;
   iconPath?: string;
   timeout?: number;
+  sseReadTimeout?: number;
   url?: string;
 
   /**
@@ -356,6 +1127,88 @@ export class MCPConnection extends EventEmitter {
    * Used to detect if connection is stale compared to updated config.
    */
   public readonly createdAt: number;
+
+  private static circuitBreakers: Map<string, CircuitBreakerState> = new Map();
+
+  public static clearCooldown(serverName: string): void {
+    MCPConnection.circuitBreakers.delete(serverName);
+    logger.debug(`[MCP][${serverName}] Circuit breaker state cleared`);
+  }
+
+  private getCircuitBreaker(): CircuitBreakerState {
+    let cb = MCPConnection.circuitBreakers.get(this.serverName);
+    if (!cb) {
+      cb = {
+        cycleCount: 0,
+        cycleWindowStart: Date.now(),
+        cooldownUntil: 0,
+        failedRounds: 0,
+        failedWindowStart: Date.now(),
+        failedBackoffUntil: 0,
+      };
+      MCPConnection.circuitBreakers.set(this.serverName, cb);
+    }
+    return cb;
+  }
+
+  private isCircuitOpen(): boolean {
+    const cb = this.getCircuitBreaker();
+    const now = Date.now();
+    return now < cb.cooldownUntil || now < cb.failedBackoffUntil;
+  }
+
+  private recordCycle(): void {
+    const cb = this.getCircuitBreaker();
+    const now = Date.now();
+    if (now - cb.cycleWindowStart > mcpConfig.CB_CYCLE_WINDOW_MS) {
+      cb.cycleCount = 0;
+      cb.cycleWindowStart = now;
+    }
+    cb.cycleCount++;
+    if (cb.cycleCount >= mcpConfig.CB_MAX_CYCLES) {
+      cb.cooldownUntil = now + mcpConfig.CB_CYCLE_COOLDOWN_MS;
+      cb.cycleCount = 0;
+      cb.cycleWindowStart = now;
+      logger.warn(
+        `${this.getLogPrefix()} Circuit breaker: too many cycles, cooling down for ${mcpConfig.CB_CYCLE_COOLDOWN_MS}ms`,
+      );
+    }
+  }
+
+  private recordFailedRound(): void {
+    const cb = this.getCircuitBreaker();
+    const now = Date.now();
+    if (now - cb.failedWindowStart > mcpConfig.CB_FAILED_WINDOW_MS) {
+      cb.failedRounds = 0;
+      cb.failedWindowStart = now;
+    }
+    cb.failedRounds++;
+    if (cb.failedRounds >= mcpConfig.CB_MAX_FAILED_ROUNDS) {
+      const backoff = Math.min(
+        mcpConfig.CB_BASE_BACKOFF_MS *
+          Math.pow(2, cb.failedRounds - mcpConfig.CB_MAX_FAILED_ROUNDS),
+        mcpConfig.CB_MAX_BACKOFF_MS,
+      );
+      cb.failedBackoffUntil = now + backoff;
+      logger.warn(
+        `${this.getLogPrefix()} Circuit breaker: too many failures, backing off for ${backoff}ms`,
+      );
+    }
+  }
+
+  private resetFailedRounds(): void {
+    const cb = this.getCircuitBreaker();
+    cb.failedRounds = 0;
+    cb.failedWindowStart = Date.now();
+    cb.failedBackoffUntil = 0;
+  }
+
+  public static decrementCycleCount(serverName: string): void {
+    const cb = MCPConnection.circuitBreakers.get(serverName);
+    if (cb && cb.cycleCount > 0) {
+      cb.cycleCount--;
+    }
+  }
 
   setRequestHeaders(headers: Record<string, string> | null): void {
     if (!headers) {
@@ -378,8 +1231,11 @@ export class MCPConnection extends EventEmitter {
     this.serverName = params.serverName;
     this.userId = params.userId;
     this.useSSRFProtection = params.useSSRFProtection === true;
+    this.allowedAddresses = params.allowedAddresses ?? null;
+    this.proxyConfig = getMCPProxyConfig(params.serverConfig);
     this.iconPath = params.serverConfig.iconPath;
     this.timeout = params.serverConfig.timeout;
+    this.sseReadTimeout = params.serverConfig.sseReadTimeout;
     this.lastPingTime = Date.now();
     this.createdAt = Date.now(); // Record creation timestamp for staleness detection
     if (params.oauthTokens) {
@@ -408,95 +1264,180 @@ export class MCPConnection extends EventEmitter {
    * Factory function to create fetch functions without capturing the entire `this` context.
    * This helps prevent memory leaks by only passing necessary dependencies.
    *
-   * @param getHeaders Function to retrieve request headers
-   * @param timeout Timeout value for the agent (in milliseconds)
-   * @returns A fetch function that merges headers appropriately
+   * When `sseBodyTimeout` is provided, a second Agent is created with a much longer
+   * body timeout for GET requests (the Streamable HTTP SSE stream). POST requests
+   * continue using the normal timeout so they fail fast on real errors.
    */
   private createFetchFunction(
     getHeaders: () => Record<string, string> | null | undefined,
     timeout?: number,
+    sseBodyTimeout?: number,
     configuredSecretHeaderKeys?: ReadonlySet<string>,
+    baseUrl?: string,
+    guardStreamableHTTPResponses = false,
   ): (input: UndiciRequestInfo, init?: UndiciRequestInit) => Promise<UndiciResponse> {
+    const proxyConfig = this.proxyConfig;
     const useSSRFProtection = this.useSSRFProtection;
+    const allowedAddresses = this.allowedAddresses;
+    /** Capture only the fields needed by the fetch closure; see factory note above. */
+    const agents = this.agents;
     const logPrefix = this.getLogPrefix();
     const effectiveTimeout = timeout || DEFAULT_TIMEOUT;
+    const requestDispatchers = new Map<string, ManagedDispatcher>();
+    const ssrfConnects = new Map<string, ReturnType<typeof createSSRFSafeUndiciConnect>>();
+
+    const getSSRFConnect = (
+      targetPort: string,
+      dispatcherAllowedAddresses: string[] | null | undefined,
+      forceSafeDirectConnect: boolean,
+    ): ReturnType<typeof createSSRFSafeUndiciConnect> => {
+      const key = `${forceSafeDirectConnect ? 'redirect' : 'configured'}:${targetPort}`;
+      const existingConnect = ssrfConnects.get(key);
+      if (existingConnect) {
+        return existingConnect;
+      }
+
+      const connect = forceSafeDirectConnect
+        ? createSSRFSafeUndiciConnect()
+        : createSSRFSafeUndiciConnect(dispatcherAllowedAddresses, targetPort);
+      ssrfConnects.set(key, connect);
+      return connect;
+    };
 
     /**
-     * Builds a fresh dispatcher for a single hop. The SSRF-safe connect resolves
-     * the target host and refuses private/reserved IPs at socket-connect time
-     * (TOCTOU-safe against DNS rebinding). `forceSafeConnect` attaches it even
-     * when SSRF protection is otherwise off, so a server-controlled cross-origin
-     * redirect hop cannot slip past in allowlist deployments.
+     * Proxy selection depends on the resolved request URL, not just the
+     * configured MCP base URL. SSE message endpoints can be absolute URLs, so
+     * cache dispatchers by the target URL's proxy decision and connect policy.
      */
-    const makeDispatcher = (forceSafeConnect: boolean): Agent => {
-      const needsSSRFConnect = useSSRFProtection || forceSafeConnect;
-      return new Agent({
-        bodyTimeout: effectiveTimeout,
+    const getRequestDispatcher = (
+      isGetRequest: boolean,
+      targetUrlString: string,
+      dispatcherAllowedAddresses: string[] | null | undefined,
+      forceSafeDirectConnect = false,
+    ): ManagedDispatcher => {
+      const bodyTimeout =
+        isGetRequest && sseBodyTimeout != null ? sseBodyTimeout : effectiveTimeout;
+      const proxyUrl = getProxyUrlForRequest(proxyConfig, targetUrlString);
+      const targetPort = getUrlPort(targetUrlString);
+      const needsSSRFConnect = !proxyUrl && (useSSRFProtection || forceSafeDirectConnect);
+      const key = [
+        bodyTimeout,
+        proxyUrl ?? 'direct',
+        needsSSRFConnect ? targetPort : 'open',
+        forceSafeDirectConnect ? 'redirect' : 'configured',
+      ].join(':');
+      const existingAgent = requestDispatchers.get(key);
+      if (existingAgent) {
+        return existingAgent;
+      }
+
+      const connect = needsSSRFConnect
+        ? getSSRFConnect(targetPort, dispatcherAllowedAddresses, forceSafeDirectConnect)
+        : undefined;
+      const agent = createMCPDispatcher({
+        bodyTimeout,
         headersTimeout: effectiveTimeout,
-        ...(needsSSRFConnect ? { connect: createSSRFSafeUndiciConnect() } : {}),
+        proxyUrl,
+        ...(connect != null ? { connect } : {}),
       });
+      requestDispatchers.set(key, agent);
+      agents.push(agent);
+      return agent;
     };
+
+    if (baseUrl) {
+      getRequestDispatcher(false, baseUrl, allowedAddresses);
+      if (sseBodyTimeout != null) {
+        getRequestDispatcher(true, baseUrl, allowedAddresses);
+      }
+    }
 
     return async function customFetch(
       input: UndiciRequestInfo,
       init?: UndiciRequestInit,
     ): Promise<UndiciResponse> {
+      /**
+       * Resolve the input shape upfront so the redirect loop can work with a
+       * (string url, init) pair uniformly. When `input` is a `Request`, we
+       * pull its method, headers, and body into the init — the body is
+       * buffered because `Request.body` is a one-shot stream that can't be
+       * replayed across redirect hops, and switching `url` to the new
+       * `Location` would otherwise drop the original method/body and turn a
+       * redirected POST into a GET with no payload.
+       */
       const { urlString, resolvedInit } = await resolveFetchInput(input, init);
+
+      const isGet = (resolvedInit?.method ?? 'GET').toUpperCase() === 'GET';
       const requestHeaders = getHeaders();
       /**
-       * Runtime `setRequestHeaders` values plus any config-baked header keys are
-       * all treated as credentials and stripped alongside the well-known
-       * credential headers on any cross-origin redirect hop.
+       * Headers that originated from user/server configuration — runtime
+       * `setRequestHeaders` plus any keys baked into the transport at
+       * construction time (e.g. `serverConfig.headers` API keys). All are
+       * treated as credentials and stripped on cross-origin redirect.
        */
       const secretHeaderKeys: ReadonlySet<string> = new Set([
         ...Object.keys(requestHeaders ?? {}).map((key) => key.toLowerCase()),
         ...(configuredSecretHeaderKeys ?? []),
       ]);
 
-      const originalOrigin = new URL(urlString).origin;
       let currentUrlString = urlString;
+      let currentAllowedAddresses = allowedAddresses;
       let forceRedirectSSRFConnect = false;
       let currentInit = buildFetchInit(
         resolvedInit,
-        makeDispatcher(forceRedirectSSRFConnect),
+        getRequestDispatcher(isGet, currentUrlString, currentAllowedAddresses),
         requestHeaders,
       );
-
+      const originalOrigin = new URL(currentUrlString).origin;
       for (let redirects = 0; ; redirects++) {
+        await assertProxiedRequestTargetAllowed(
+          currentUrlString,
+          proxyConfig,
+          useSSRFProtection,
+          currentAllowedAddresses,
+        );
         const response = await undiciFetch(currentUrlString, currentInit);
         const isMethodPreservingRedirect = response.status === 307 || response.status === 308;
+        const responseContext = {
+          logPrefix,
+          method: (currentInit?.method ?? 'GET').toUpperCase(),
+          url: currentUrlString,
+          requestIds: getJSONRPCRequestIds(currentInit?.body),
+        };
 
-        /**
-         * Non-redirect responses and non-method-preserving redirects (301/302/
-         * 303) are returned unfollowed — the MCP SDK rejects a bare 3xx, which
-         * closes the SSRF-via-301/302 hole without silently following. Only
-         * 307/308 are followed, and only after the target clears SSRF checks.
-         */
         if (!isMethodPreservingRedirect || redirects >= MAX_REDIRECTS) {
-          return response;
+          return guardStreamableHTTPResponses
+            ? guardMCPStreamableHTTPResponse(response, responseContext)
+            : response;
         }
 
         const location = response.headers.get('location');
         if (!location) {
-          return response;
+          return guardStreamableHTTPResponses
+            ? guardMCPStreamableHTTPResponse(response, responseContext)
+            : response;
         }
 
         const targetUrl = new URL(location, currentUrlString);
         const isCrossOriginRedirect = targetUrl.origin !== originalOrigin;
 
         /**
-         * Re-validate every redirect target. `isSSRFTarget` catches literal
-         * private/reserved/metadata IPs (which undici's connect-time lookup
-         * skips because no DNS resolution happens for an IP literal);
-         * `resolveHostnameSSRF` catches hostnames that resolve to private IPs.
-         * Redirect targets are server-controlled, so they get no allowlist
-         * exemption — a blocked hop returns the redirect unfollowed.
+         * Keep the standalone check for immediate literal/current-DNS blocks.
+         * Cross-origin allowlist redirects also switch to a connect-time
+         * SSRF-safe dispatcher below so DNS rebinding cannot change the
+         * address between this check and the socket connection.
+         *
+         * `allowedAddresses` is intentionally NOT consulted on either layer:
+         * redirect targets are server-controlled (the MCP server's response
+         * chooses where to send us), so they must not inherit the admin's
+         * exemption for the originally-configured URL. A legitimate self-
+         * redirect from a permitted private host is still blocked here, by
+         * design — letting redirect targets inherit the exemption would open
+         * an SSRF amplification primitive.
          */
         if (isSSRFTarget(targetUrl.hostname) || (await resolveHostnameSSRF(targetUrl.hostname))) {
           logger.warn(
-            `${logPrefix} Blocked MCP redirect to private/reserved address: ${sanitizeUrlForLogging(
-              targetUrl,
-            )}`,
+            `[MCP] Blocked redirect to private/reserved address: ${sanitizeUrlForLogging(targetUrl)}`,
           );
           return response;
         }
@@ -514,18 +1455,37 @@ export class MCPConnection extends EventEmitter {
         }
 
         if (isCrossOriginRedirect) {
-          /**
-           * Once a server-controlled cross-origin hop is seen, pin an SSRF-safe
-           * connect for the rest of the chain so a later same-origin hop cannot
-           * reopen the rebinding gap in allowlist mode.
-           */
+          currentAllowedAddresses = null;
           forceRedirectSSRFConnect = true;
+          /**
+           * Once a server-controlled cross-origin hop is seen, keep the safe
+           * dispatcher for the rest of this redirect chain. Restoring the
+           * original dispatcher on a later hop back to the original origin
+           * would re-open the allowlist-mode rebinding gap. When the original
+           * dispatcher carries `allowedAddresses`, this also prevents a
+           * redirect from inheriting that port-scoped exemption.
+           */
+          currentInit = {
+            ...currentInit,
+            dispatcher: getRequestDispatcher(
+              isGet,
+              targetUrl.href,
+              currentAllowedAddresses,
+              forceRedirectSSRFConnect,
+            ),
+          };
+        } else {
+          currentInit = {
+            ...currentInit,
+            dispatcher: getRequestDispatcher(
+              isGet,
+              targetUrl.href,
+              currentAllowedAddresses,
+              forceRedirectSSRFConnect,
+            ),
+          };
         }
 
-        currentInit = {
-          ...currentInit,
-          dispatcher: makeDispatcher(forceRedirectSSRFConnect),
-        };
         currentUrlString = targetUrl.href;
       }
     };
@@ -567,21 +1527,34 @@ export class MCPConnection extends EventEmitter {
             env: { ...getDefaultEnvironment(), ...(options.env ?? {}) },
           });
 
-        case 'websocket':
+        case 'websocket': {
           if (!isWebSocketOptions(options)) {
             throw new Error('Invalid options for websocket transport.');
           }
           this.url = options.url;
-          if (this.useSSRFProtection) {
-            const wsHostname = new URL(options.url).hostname;
-            const isSSRF = await resolveHostnameSSRF(wsHostname);
-            if (isSSRF) {
-              throw new Error(
-                `SSRF protection: WebSocket host "${wsHostname}" resolved to a private/reserved IP address`,
-              );
-            }
+          /**
+           * SSRF pre-check: always validate resolved IPs for WebSocket, regardless
+           * of allowlist configuration. Allowlisting a domain grants trust to that
+           * name, not to whatever IP it resolves to at runtime (DNS rebinding).
+           *
+           * Note: WebSocketClientTransport does its own DNS resolution, creating a
+           * small TOCTOU window. This is an SDK limitation — the transport accepts
+           * only a URL with no custom DNS lookup hook.
+           */
+          const wsUrl = new URL(options.url);
+          const wsHostname = wsUrl.hostname;
+          const isSSRF = await resolveHostnameSSRF(
+            wsHostname,
+            this.allowedAddresses,
+            getUrlPort(wsUrl),
+          );
+          if (isSSRF) {
+            throw new Error(
+              `SSRF protection: WebSocket host "${wsHostname}" resolved to a private/reserved IP address`,
+            );
           }
           return new WebSocketClientTransport(new URL(options.url));
+        }
 
         case 'sse': {
           if (!isSSEOptions(options)) {
@@ -605,7 +1578,36 @@ export class MCPConnection extends EventEmitter {
            * The connect timeout is extended because proxies may delay initial response.
            */
           const sseTimeout = this.timeout || SSE_CONNECT_TIMEOUT;
-          const ssrfConnect = this.useSSRFProtection ? createSSRFSafeUndiciConnect() : undefined;
+          const sseAgents = new Map<string, ManagedDispatcher>();
+          const getSSEDispatcher = (targetUrlString: string): ManagedDispatcher => {
+            const proxyUrl = getProxyUrlForRequest(this.proxyConfig, targetUrlString);
+            const targetPort = getUrlPort(targetUrlString);
+            const key = `${proxyUrl ?? 'direct'}:${this.useSSRFProtection && !proxyUrl ? targetPort : 'open'}`;
+            const existingAgent = sseAgents.get(key);
+            if (existingAgent) {
+              return existingAgent;
+            }
+
+            const connect =
+              this.useSSRFProtection && !proxyUrl
+                ? createSSRFSafeUndiciConnect(this.allowedAddresses, targetPort)
+                : undefined;
+            const agent = createMCPDispatcher({
+              bodyTimeout: sseTimeout,
+              headersTimeout: sseTimeout,
+              keepAliveTimeout: sseTimeout,
+              keepAliveMaxTimeout: sseTimeout * 2,
+              proxyUrl,
+              ...(connect != null ? { connect } : {}),
+            });
+            sseAgents.set(key, agent);
+            this.agents.push(agent);
+            return agent;
+          };
+          getSSEDispatcher(options.url);
+          const sseConfiguredSecretHeaderKeys: ReadonlySet<string> = new Set(
+            Object.keys(headers).map((key) => key.toLowerCase()),
+          );
           const transport = new SSEClientTransport(url, {
             requestInit: {
               /** User/OAuth headers override SSE defaults */
@@ -613,22 +1615,25 @@ export class MCPConnection extends EventEmitter {
               signal: abortController.signal,
             },
             eventSourceInit: {
-              fetch: (url, init) => {
+              fetch: async (url, init) => {
+                const { urlString, resolvedInit } = await resolveFetchInput(
+                  url as UndiciRequestInfo,
+                  init as UndiciRequestInit,
+                );
+                await assertProxiedRequestTargetAllowed(
+                  urlString,
+                  this.proxyConfig,
+                  this.useSSRFProtection,
+                  this.allowedAddresses,
+                );
                 /** Merge headers: SSE defaults < init headers < user headers (user wins) */
                 const fetchHeaders = new Headers(
-                  Object.assign({}, SSE_REQUEST_HEADERS, init?.headers, headers),
+                  Object.assign({}, SSE_REQUEST_HEADERS, resolvedInit?.headers, headers),
                 );
-                const agent = new Agent({
-                  bodyTimeout: sseTimeout,
-                  headersTimeout: sseTimeout,
-                  /** Extended keep-alive for long-lived SSE connections */
-                  keepAliveTimeout: sseTimeout,
-                  keepAliveMaxTimeout: sseTimeout * 2,
-                  ...(ssrfConnect != null ? { connect: ssrfConnect } : {}),
-                });
-                return undiciFetch(url, {
-                  ...init,
-                  dispatcher: agent,
+                return undiciFetch(urlString, {
+                  ...resolvedInit,
+                  redirect: 'manual',
+                  dispatcher: getSSEDispatcher(urlString),
                   headers: fetchHeaders,
                 });
               },
@@ -636,17 +1641,15 @@ export class MCPConnection extends EventEmitter {
             fetch: this.createFetchFunction(
               this.getRequestHeaders.bind(this),
               sseTimeout,
-              new Set(Object.keys(headers).map((key) => key.toLowerCase())),
+              undefined,
+              sseConfiguredSecretHeaderKeys,
+              options.url,
             ) as unknown as FetchLike,
           });
 
           transport.onclose = () => {
             logger.info(`${this.getLogPrefix()} SSE transport closed`);
             this.emit('connectionChange', 'disconnected');
-          };
-
-          transport.onmessage = (message) => {
-            logger.info(`${this.getLogPrefix()} Message received: ${JSON.stringify(message)}`);
           };
 
           this.setupTransportErrorHandlers(transport);
@@ -670,6 +1673,9 @@ export class MCPConnection extends EventEmitter {
             headers['Authorization'] = `Bearer ${this.oauthTokens.access_token}`;
           }
 
+          const httpConfiguredSecretHeaderKeys: ReadonlySet<string> = new Set(
+            Object.keys(headers).map((key) => key.toLowerCase()),
+          );
           const transport = new StreamableHTTPClientTransport(url, {
             requestInit: {
               headers,
@@ -678,17 +1684,16 @@ export class MCPConnection extends EventEmitter {
             fetch: this.createFetchFunction(
               this.getRequestHeaders.bind(this),
               this.timeout,
-              new Set(Object.keys(headers).map((key) => key.toLowerCase())),
+              this.sseReadTimeout || DEFAULT_SSE_READ_TIMEOUT,
+              httpConfiguredSecretHeaderKeys,
+              options.url,
+              true,
             ) as unknown as FetchLike,
           });
 
           transport.onclose = () => {
             logger.info(`${this.getLogPrefix()} Streamable-http transport closed`);
             this.emit('connectionChange', 'disconnected');
-          };
-
-          transport.onmessage = (message: JSONRPCMessage) => {
-            logger.info(`${this.getLogPrefix()} Message received: ${JSON.stringify(message)}`);
           };
 
           this.setupTransportErrorHandlers(transport);
@@ -827,6 +1832,12 @@ export class MCPConnection extends EventEmitter {
       return;
     }
 
+    if (this.isCircuitOpen()) {
+      this.connectionState = 'error';
+      this.emit('connectionChange', 'error');
+      throw new Error(`${this.getLogPrefix()} Circuit breaker is open, connection attempt blocked`);
+    }
+
     this.emit('connectionChange', 'connecting');
 
     this.connectPromise = (async () => {
@@ -834,25 +1845,37 @@ export class MCPConnection extends EventEmitter {
         if (this.transport) {
           try {
             await this.client.close();
-            this.transport = null;
           } catch (error) {
             logger.warn(`${this.getLogPrefix()} Error closing connection:`, error);
           }
+          this.transport = null;
+          await this.closeAgents();
         }
 
-        this.transport = await this.constructTransport(this.options);
-        this.setupTransportDebugHandlers();
+        this.transport = await runOutsideTracing(() => this.constructTransport(this.options));
+        this.patchTransportSend();
 
-        const connectTimeout = this.options.initTimeout ?? 120000;
-        await withTimeout(
-          this.client.connect(this.transport),
-          connectTimeout,
-          `Connection timeout after ${connectTimeout}ms`,
+        const connectTimeout = this.options.initTimeout ?? DEFAULT_INIT_TIMEOUT;
+        await runOutsideTracing(() =>
+          withTimeout(
+            this.client.connect(this.transport!),
+            connectTimeout,
+            `Connection timeout after ${connectTimeout}ms`,
+          ),
         );
 
+        this.setupTransportOnMessageHandler();
         this.connectionState = 'connected';
         this.emit('connectionChange', 'connected');
         this.reconnectAttempts = 0;
+        this.resetFailedRounds();
+        if (this.oauthRecovery) {
+          MCPConnection.decrementCycleCount(this.serverName);
+          this.oauthRecovery = false;
+          logger.debug(
+            `${this.getLogPrefix()} OAuth recovery: decremented cycle count after successful reconnect`,
+          );
+        }
       } catch (error) {
         // Check if it's a rate limit error - stop immediately to avoid making it worse
         if (this.isRateLimitError(error)) {
@@ -936,9 +1959,8 @@ export class MCPConnection extends EventEmitter {
           try {
             // Wait for OAuth to be handled
             await oauthHandledPromise;
-            // Reset the oauthRequired flag
             this.oauthRequired = false;
-            // Don't throw the error - just return so connection can be retried
+            this.oauthRecovery = true;
             logger.info(
               `${this.getLogPrefix()} OAuth handled successfully, connection will be retried`,
             );
@@ -954,6 +1976,7 @@ export class MCPConnection extends EventEmitter {
 
         this.connectionState = 'error';
         this.emit('connectionChange', 'error');
+        this.recordFailedRound();
         throw error;
       } finally {
         this.connectPromise = null;
@@ -963,14 +1986,10 @@ export class MCPConnection extends EventEmitter {
     return this.connectPromise;
   }
 
-  private setupTransportDebugHandlers(): void {
+  private patchTransportSend(): void {
     if (!this.transport) {
       return;
     }
-
-    this.transport.onmessage = (msg) => {
-      logger.debug(`${this.getLogPrefix()} Transport received: ${JSON.stringify(msg)}`);
-    };
 
     const originalSend = this.transport.send.bind(this.transport);
     this.transport.send = async (msg) => {
@@ -980,14 +1999,35 @@ export class MCPConnection extends EventEmitter {
         }
         this.lastPingTime = Date.now();
       }
-      logger.debug(`${this.getLogPrefix()} Transport sending: ${JSON.stringify(msg)}`);
+      const method = 'method' in msg ? msg.method : undefined;
+      const id = 'id' in msg ? (msg as { id: string | number | null }).id : undefined;
+      logger.debug(
+        `${this.getLogPrefix()} Transport sending: method=${method ?? 'response'} id=${id ?? 'none'}`,
+      );
       return originalSend(msg);
+    };
+  }
+
+  private setupTransportOnMessageHandler(): void {
+    if (!this.transport?.onmessage) {
+      return;
+    }
+
+    const sdkHandler = this.transport.onmessage;
+    this.transport.onmessage = (msg) => {
+      const method = 'method' in msg ? msg.method : undefined;
+      const id = 'id' in msg ? (msg as { id: string | number | null }).id : undefined;
+      logger.debug(
+        `${this.getLogPrefix()} Transport received: method=${method ?? 'response'} id=${id ?? 'none'}`,
+      );
+      sdkHandler(msg);
     };
   }
 
   async connect(): Promise<void> {
     try {
-      await this.disconnect();
+      // preserve cycle tracking across reconnects so the circuit breaker can detect rapid cycling
+      await this.disconnect(false);
       await this.connectClient();
       if (!(await this.isConnected())) {
         throw new Error('Connection not established');
@@ -1000,7 +2040,26 @@ export class MCPConnection extends EventEmitter {
 
   private setupTransportErrorHandlers(transport: Transport): void {
     transport.onerror = (error) => {
-      // Extract meaningful error information (handles "SSE error: undefined" cases)
+      const rawMessage =
+        error && typeof error === 'object' ? ((error as { message?: string }).message ?? '') : '';
+
+      /**
+       * The MCP SDK's StreamableHTTPClientTransport fires onerror for SSE GET stream
+       * disconnects but also handles reconnection internally via _scheduleReconnection.
+       * Escalating these to a full transport rebuild creates a redundant reconnection
+       * loop. Log at debug level and let the SDK recover the GET stream on its own.
+       *
+       * "Maximum reconnection attempts … exceeded" means the SDK gave up — that one
+       * must fall through so our higher-level reconnection takes over.
+       */
+      if (
+        rawMessage.startsWith(SDK_SSE_STREAM_DISCONNECTED) ||
+        rawMessage.startsWith(SDK_SSE_RECONNECT_FAILED)
+      ) {
+        logger.debug(`${this.getLogPrefix()} SDK SSE stream recovery in progress: ${rawMessage}`);
+        return;
+      }
+
       const {
         message: errorMessage,
         code: errorCode,
@@ -1008,10 +2067,24 @@ export class MCPConnection extends EventEmitter {
         isTransient,
       } = extractSSEErrorMessage(error);
 
-      // Ignore SSE 404 errors for servers that don't support SSE
-      if (errorCode === 404 && errorMessage.toLowerCase().includes('failed to open sse stream')) {
-        logger.warn(`${this.getLogPrefix()} SSE stream not available (404). Ignoring.`);
-        return;
+      if (errorCode === 400 || errorCode === 404 || errorCode === 405 || errorCode === 406) {
+        const hasSession =
+          'sessionId' in transport &&
+          (transport as { sessionId?: string }).sessionId != null &&
+          (transport as { sessionId?: string }).sessionId !== '';
+
+        if (!hasSession && errorMessage.toLowerCase().includes('failed to open sse stream')) {
+          logger.warn(
+            `${this.getLogPrefix()} SSE stream not available (${errorCode}), no session. Ignoring.`,
+          );
+          return;
+        }
+
+        if (hasSession) {
+          logger.warn(
+            `${this.getLogPrefix()} ${errorCode} with active session — session lost, triggering reconnection.`,
+          );
+        }
       }
 
       // Check if it's an OAuth authentication error
@@ -1069,12 +2142,24 @@ export class MCPConnection extends EventEmitter {
     };
   }
 
-  public async disconnect(): Promise<void> {
+  private async closeAgents(): Promise<void> {
+    const logPrefix = this.getLogPrefix();
+    const closing = this.agents.map((agent) =>
+      agent.close().catch((err: unknown) => {
+        logger.debug(`${logPrefix} Agent close error (non-fatal):`, err);
+      }),
+    );
+    this.agents = [];
+    await Promise.all(closing);
+  }
+
+  public async disconnect(resetCycleTracking = true): Promise<void> {
     try {
       if (this.transport) {
         await this.client.close();
         this.transport = null;
       }
+      await this.closeAgents();
       if (this.connectionState === 'disconnected') {
         return;
       }
@@ -1082,6 +2167,9 @@ export class MCPConnection extends EventEmitter {
       this.emit('connectionChange', 'disconnected');
     } finally {
       this.connectPromise = null;
+      if (!resetCycleTracking) {
+        this.recordCycle();
+      }
     }
   }
 
@@ -1226,6 +2314,10 @@ export class MCPConnection extends EventEmitter {
       }
       // Check for authentication required
       if (message.includes('authentication required') || message.includes('unauthorized')) {
+        return true;
+      }
+      // Check for missing authorization values (e.g., Amazon Ads MCP returns HTTP 400 with this)
+      if (message.includes('no authorization')) {
         return true;
       }
     }

--- a/packages/api/src/mcp/mcpConfig.ts
+++ b/packages/api/src/mcp/mcpConfig.ts
@@ -12,4 +12,18 @@ export const mcpConfig = {
   USER_CONNECTION_IDLE_TIMEOUT: math(
     process.env.MCP_USER_CONNECTION_IDLE_TIMEOUT ?? 15 * 60 * 1000,
   ),
+  /** Max connect/disconnect cycles before the circuit breaker trips. Default: 7 */
+  CB_MAX_CYCLES: math(process.env.MCP_CB_MAX_CYCLES ?? 7),
+  /** Sliding window (ms) for counting cycles. Default: 45s */
+  CB_CYCLE_WINDOW_MS: math(process.env.MCP_CB_CYCLE_WINDOW_MS ?? 45_000),
+  /** Cooldown (ms) after the cycle breaker trips. Default: 15s */
+  CB_CYCLE_COOLDOWN_MS: math(process.env.MCP_CB_CYCLE_COOLDOWN_MS ?? 15_000),
+  /** Max consecutive failed connection rounds before backoff. Default: 3 */
+  CB_MAX_FAILED_ROUNDS: math(process.env.MCP_CB_MAX_FAILED_ROUNDS ?? 3),
+  /** Sliding window (ms) for counting failed rounds. Default: 120s */
+  CB_FAILED_WINDOW_MS: math(process.env.MCP_CB_FAILED_WINDOW_MS ?? 120_000),
+  /** Base backoff (ms) after failed round threshold is reached. Default: 30s */
+  CB_BASE_BACKOFF_MS: math(process.env.MCP_CB_BASE_BACKOFF_MS ?? 30_000),
+  /** Max backoff cap (ms) for exponential backoff. Default: 300s */
+  CB_MAX_BACKOFF_MS: math(process.env.MCP_CB_MAX_BACKOFF_MS ?? 300_000),
 };

--- a/packages/api/src/mcp/oauth/OAuthReconnectionTracker.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionTracker.ts
@@ -1,6 +1,12 @@
+interface FailedMeta {
+  attempts: number;
+  lastFailedAt: number;
+}
+
+const COOLDOWN_SCHEDULE_MS = [5 * 60 * 1000, 10 * 60 * 1000, 20 * 60 * 1000, 30 * 60 * 1000];
+
 export class OAuthReconnectionTracker {
-  /** Map of userId -> Set of serverNames that have failed reconnection */
-  private failed: Map<string, Set<string>> = new Map();
+  private failedMeta: Map<string, Map<string, FailedMeta>> = new Map();
   /** Map of userId -> Set of serverNames that are actively reconnecting */
   private active: Map<string, Set<string>> = new Map();
   /** Map of userId:serverName -> timestamp when reconnection started */
@@ -9,7 +15,17 @@ export class OAuthReconnectionTracker {
   private readonly RECONNECTION_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
 
   public isFailed(userId: string, serverName: string): boolean {
-    return this.failed.get(userId)?.has(serverName) ?? false;
+    const meta = this.failedMeta.get(userId)?.get(serverName);
+    if (!meta) {
+      return false;
+    }
+    const idx = Math.min(meta.attempts - 1, COOLDOWN_SCHEDULE_MS.length - 1);
+    const cooldown = COOLDOWN_SCHEDULE_MS[idx];
+    const elapsed = Date.now() - meta.lastFailedAt;
+    if (elapsed >= cooldown) {
+      return false;
+    }
+    return true;
   }
 
   /** Check if server is in the active set (original simple check) */
@@ -48,11 +64,15 @@ export class OAuthReconnectionTracker {
   }
 
   public setFailed(userId: string, serverName: string): void {
-    if (!this.failed.has(userId)) {
-      this.failed.set(userId, new Set());
+    if (!this.failedMeta.has(userId)) {
+      this.failedMeta.set(userId, new Map());
     }
-
-    this.failed.get(userId)?.add(serverName);
+    const userMap = this.failedMeta.get(userId)!;
+    const existing = userMap.get(serverName);
+    userMap.set(serverName, {
+      attempts: (existing?.attempts ?? 0) + 1,
+      lastFailedAt: Date.now(),
+    });
   }
 
   public setActive(userId: string, serverName: string): void {
@@ -68,10 +88,10 @@ export class OAuthReconnectionTracker {
   }
 
   public removeFailed(userId: string, serverName: string): void {
-    const userServers = this.failed.get(userId);
-    userServers?.delete(serverName);
-    if (userServers?.size === 0) {
-      this.failed.delete(userId);
+    const userMap = this.failedMeta.get(userId);
+    userMap?.delete(serverName);
+    if (userMap?.size === 0) {
+      this.failedMeta.delete(userId);
     }
   }
 
@@ -85,5 +105,18 @@ export class OAuthReconnectionTracker {
     /** Clear timestamp tracking */
     const key = `${userId}:${serverName}`;
     this.activeTimestamps.delete(key);
+  }
+
+  /** Returns map sizes for diagnostics */
+  public getStats(): {
+    usersWithFailedServers: number;
+    usersWithActiveReconnections: number;
+    activeTimestamps: number;
+  } {
+    return {
+      usersWithFailedServers: this.failedMeta.size,
+      usersWithActiveReconnections: this.active.size,
+      activeTimestamps: this.activeTimestamps.size,
+    };
   }
 }

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -20,6 +20,8 @@ const BaseOptionsSchema = z.object({
   iconPath: z.string().optional(),
   timeout: z.number().optional(),
   initTimeout: z.number().optional(),
+  /** Idle read timeout (ms) for streamable-HTTP GET SSE streams between server pushes */
+  sseReadTimeout: z.number().int().positive().optional(),
   /** Controls visibility in chat dropdown menu (MCPSelect) */
   chatMenu: z.boolean().optional(),
   /**
@@ -101,6 +103,30 @@ const BaseOptionsSchema = z.object({
     .optional(),
 });
 
+/**
+ * Outbound proxy URL for a remote MCP transport. Accepts http(s) and SOCKS
+ * proxies; the value may reference an env var via `${VAR}` which is resolved
+ * before validation. Admin-only — never accepted from UI/API input.
+ */
+const ProxyUrlSchema = z
+  .string()
+  .transform((val: string) => extractEnvVariable(val))
+  .pipe(z.string().url())
+  .refine(
+    (val: string) => {
+      const protocol = new URL(val).protocol;
+      return (
+        protocol === 'http:' ||
+        protocol === 'https:' ||
+        protocol === 'socks:' ||
+        protocol === 'socks5:'
+      );
+    },
+    {
+      message: 'Proxy URL must use http://, https://, socks://, or socks5://',
+    },
+  );
+
 export const StdioOptionsSchema = BaseOptionsSchema.extend({
   type: z.literal('stdio').optional(),
   /**
@@ -161,6 +187,8 @@ export const WebSocketOptionsSchema = BaseOptionsSchema.extend({
 export const SSEOptionsSchema = BaseOptionsSchema.extend({
   type: z.literal('sse').optional(),
   headers: z.record(z.string(), z.string()).optional(),
+  /** Optional outbound proxy URL for this remote MCP transport */
+  proxy: ProxyUrlSchema.optional(),
   url: z
     .string()
     .transform((val: string) => extractEnvVariable(val))
@@ -179,6 +207,8 @@ export const SSEOptionsSchema = BaseOptionsSchema.extend({
 export const StreamableHTTPOptionsSchema = BaseOptionsSchema.extend({
   type: z.union([z.literal('streamable-http'), z.literal('http')]),
   headers: z.record(z.string(), z.string()).optional(),
+  /** Optional outbound proxy URL for this remote MCP transport */
+  proxy: ProxyUrlSchema.optional(),
   url: z
     .string()
     .transform((val: string) => extractEnvVariable(val))
@@ -213,6 +243,7 @@ const omitServerManagedFields = <T extends z.ZodObject<z.ZodRawShape>>(schema: T
     startup: true,
     timeout: true,
     initTimeout: true,
+    sseReadTimeout: true,
     chatMenu: true,
     serverInstructions: true,
     requiresOAuth: true,
@@ -232,8 +263,14 @@ const omitServerManagedFields = <T extends z.ZodObject<z.ZodRawShape>>(schema: T
  */
 export const MCPServerUserInputSchema = z.union([
   omitServerManagedFields(WebSocketOptionsSchema),
-  omitServerManagedFields(SSEOptionsSchema),
-  omitServerManagedFields(StreamableHTTPOptionsSchema),
+  omitServerManagedFields(SSEOptionsSchema).extend({
+    /** SECURITY: outbound proxy is admin-only; never accepted from UI/API input */
+    proxy: z.never().optional(),
+  }),
+  omitServerManagedFields(StreamableHTTPOptionsSchema).extend({
+    /** SECURITY: outbound proxy is admin-only; never accepted from UI/API input */
+    proxy: z.never().optional(),
+  }),
 ]);
 
 export type MCPServerUserInput = z.infer<typeof MCPServerUserInputSchema>;


### PR DESCRIPTION
Upstream sync landed the MCP transport TESTS but reverted the IMPLEMENTATIONS (babel-transpiled tests hid it; packages/api tests never ran in Hanzo CI). Ported real impls from upstream 7cd467a528: proxy support (serverConfig.proxy + HTTP(S)_PROXY/NO_PROXY semantics, per-URL ProxyAgent/Agent), proxied-target SSRF preflight, response-size caps (MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES/MAX_LINE_BYTES), WS SSRF even with useSSRFProtection off; SSRF helpers in auth/domain.ts+agent.ts; circuit-breaker CB_* + progressive cooldown. CI GATE: new test:transport (13 suites/491 tests) wired into test.yml primary path — a future half-port fails loudly. 491/491 green, no regressions, proxy is admin-only (z.never() in user input). Adjacent MCP-OAuth-flow drift flagged as separate pre-existing tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)