### PR TITLE
fix(store/sqlite): guard engine setPath/deletePath against prototype pollution

### DIFF
--- a/packages/data-schemas/src/stores/sqlite/engine.spec.ts
+++ b/packages/data-schemas/src/stores/sqlite/engine.spec.ts
@@ -127,6 +127,45 @@ describe('sqlite engine — applyUpdate', () => {
   });
 });
 
+describe('sqlite engine — prototype pollution guard', () => {
+  afterEach(() => {
+    // Fail loudly if any case leaked onto a shared prototype.
+    delete ({} as Record<string, unknown>).polluted;
+    delete (Object.prototype as Record<string, unknown>).polluted;
+  });
+
+  it('ignores a dotted __proto__ write in $set (no global pollution)', () => {
+    const out = applyUpdate({ a: 1 }, { $set: { '__proto__.polluted': 'yes' } }, false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+    expect(out).toEqual({ a: 1 });
+  });
+
+  it('ignores constructor.prototype pollution in $set', () => {
+    applyUpdate({}, { $set: { 'constructor.prototype.polluted': 'yes' } }, false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('ignores a single-segment own __proto__ key (JSON-sourced payload)', () => {
+    // JSON.parse creates a real own "__proto__" key (unlike an object literal,
+    // which would set the prototype) — the shape a malicious request body takes.
+    const malicious = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+    const out = applyUpdate({ a: 1 }, { $set: malicious }, false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(out).toEqual({ a: 1 });
+  });
+
+  it('ignores __proto__ paths via $setOnInsert and $inc', () => {
+    applyUpdate({}, { $setOnInsert: { '__proto__.polluted': 1 } }, true);
+    applyUpdate({}, { $inc: { '__proto__.polluted': 1 } }, false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('still writes legitimate nested paths', () => {
+    expect(applyUpdate({}, { $set: { 'a.b.c': 1 } }, false)).toEqual({ a: { b: { c: 1 } } });
+  });
+});
+
 describe('sqlite engine — projection & sort', () => {
   const doc = { _id: '1', a: 1, b: 2, c: 3 };
 

--- a/packages/data-schemas/src/stores/sqlite/engine.ts
+++ b/packages/data-schemas/src/stores/sqlite/engine.ts
@@ -54,12 +54,32 @@ export function hasPath(doc: Doc, path: string): boolean {
   return false;
 }
 
+/**
+ * Keys that must never be walked or written through a dotted update path:
+ * writing `__proto__.x` or `constructor.prototype.x` would mutate a shared
+ * prototype (prototype pollution). Update keys are attacker-influenced — they
+ * arrive verbatim from `$set`/`$unset`/`$inc`/`$push`/… documents (conversation
+ * import, `saveConvo`, agent metadata) — so a malicious dotted key is neutralised
+ * here rather than trusted. A path containing any unsafe segment is a no-op.
+ */
+const UNSAFE_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+function hasUnsafeSegment(keys: string[]): boolean {
+  return keys.some((k) => UNSAFE_KEYS.has(k));
+}
+
 function setPath(doc: Doc, path: string, value: unknown): void {
   if (!path.includes('.')) {
+    if (UNSAFE_KEYS.has(path)) {
+      return;
+    }
     doc[path] = value;
     return;
   }
   const keys = path.split('.');
+  if (hasUnsafeSegment(keys)) {
+    return;
+  }
   let cur: Doc = doc;
   for (let i = 0; i < keys.length - 1; i++) {
     const next = cur[keys[i]];
@@ -73,10 +93,16 @@ function setPath(doc: Doc, path: string, value: unknown): void {
 
 function deletePath(doc: Doc, path: string): void {
   if (!path.includes('.')) {
+    if (UNSAFE_KEYS.has(path)) {
+      return;
+    }
     delete doc[path];
     return;
   }
   const keys = path.split('.');
+  if (hasUnsafeSegment(keys)) {
+    return;
+  }
   let cur: Doc = doc;
   for (let i = 0; i < keys.length - 1; i++) {
     const next = cur[keys[i]];


### PR DESCRIPTION
## What

The SQLite store engine (`packages/data-schemas/src/stores/sqlite/engine.ts`, landed in v0.9.15's dual-write cutover) feeds **attacker-influenced update keys** — `$set`/`$unset`/`$inc`/`$push`/`$addToSet` fields from conversation import, `saveConvo`, agent metadata — straight into `setPath`/`deletePath`. Those walked `cur['__proto__']` / `cur['constructor']` with no guard, so a dotted key like `__proto__.polluted` (or a JSON-sourced own `__proto__` key) could mutate a shared prototype: **global prototype pollution**.

## Fix

Reject any path whose segments include `__proto__` / `prototype` / `constructor` (dotted and single-segment own-key cases). Legitimate nested writes (`a.b.c`) are unaffected — a no-op only for the dangerous keys.

## Tests

`engine.spec.ts` +5 cases: dotted `$set`, `constructor.prototype`, JSON-sourced own `__proto__`, `$setOnInsert`/`$inc`, and 'still writes legitimate nested paths'. **27/27 green on Node 20** (engine is pure-JS, no `node:sqlite` dependency).

Purely additive guards; no behavior change for any legitimate document. Same class of bug that #48's red review caught in the parallel `api/db/base` query engine.