### PR TITLE
fix(chat/sse): surface upstream errors instead of a silent empty bubble

### DIFF
--- a/api/server/controllers/agents/__tests__/emptyResponse.spec.js
+++ b/api/server/controllers/agents/__tests__/emptyResponse.spec.js
@@ -1,0 +1,61 @@
+const { ContentTypes } = require('librechat-data-provider');
+const { isEmptyAgentResponse } = require('../emptyResponse');
+
+describe('isEmptyAgentResponse', () => {
+  it('treats nullish responses as empty', () => {
+    expect(isEmptyAgentResponse(undefined)).toBe(true);
+    expect(isEmptyAgentResponse(null)).toBe(true);
+    expect(isEmptyAgentResponse({})).toBe(true);
+  });
+
+  it('is empty when content array is empty and text is blank', () => {
+    // The exact silent-failure shape: agents endpoint sets text:'' and the
+    // stream yielded zero deltas, so content is [].
+    expect(isEmptyAgentResponse({ text: '', content: [] })).toBe(true);
+    expect(isEmptyAgentResponse({ text: '   ', content: [] })).toBe(true);
+  });
+
+  it('is empty when the only content part is a blank text part', () => {
+    expect(
+      isEmptyAgentResponse({ text: '', content: [{ type: ContentTypes.TEXT, text: '' }] }),
+    ).toBe(true);
+    expect(
+      isEmptyAgentResponse({ text: '', content: [{ type: ContentTypes.TEXT, text: '  \n ' }] }),
+    ).toBe(true);
+  });
+
+  it('is NOT empty when text is present', () => {
+    expect(isEmptyAgentResponse({ text: 'hello' })).toBe(false);
+    expect(isEmptyAgentResponse({ text: 'hi', content: [] })).toBe(false);
+  });
+
+  it('is NOT empty when a text content part carries content', () => {
+    expect(
+      isEmptyAgentResponse({ text: '', content: [{ type: ContentTypes.TEXT, text: 'answer' }] }),
+    ).toBe(false);
+  });
+
+  it('is NOT empty when an error content part is present', () => {
+    // The gateway-threw path pushes an ERROR part; that must still render (never
+    // be re-flagged as empty).
+    expect(
+      isEmptyAgentResponse({
+        text: '',
+        content: [{ type: ContentTypes.ERROR, error: 'insufficient credits' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('is NOT empty when a tool_call part is present (no text yet)', () => {
+    expect(
+      isEmptyAgentResponse({
+        text: '',
+        content: [{ type: ContentTypes.TOOL_CALL, tool_call: { name: 'search' } }],
+      }),
+    ).toBe(false);
+  });
+
+  it('is NOT empty when a non-blank string part is present', () => {
+    expect(isEmptyAgentResponse({ text: '', content: ['done'] })).toBe(false);
+  });
+});

--- a/api/server/controllers/agents/__tests__/emptyResponseController.spec.js
+++ b/api/server/controllers/agents/__tests__/emptyResponseController.spec.js
@@ -1,0 +1,124 @@
+/**
+ * Proves the empty-response backstop in ResumableAgentController is WIRED to the
+ * SSE error path: a completion that returns no content (a dead key / out-of-
+ * credits stream that yields zero deltas without throwing) must surface as an
+ * `emitError` — never a silent `emitDone` with an empty message.
+ */
+
+const { ContentTypes } = require('librechat-data-provider');
+
+const mockGenerationJobManager = {
+  createJob: jest.fn(),
+  getJob: jest.fn(),
+  emitDone: jest.fn(),
+  emitError: jest.fn(),
+  emitChunk: jest.fn(),
+  completeJob: jest.fn(),
+  updateMetadata: jest.fn(),
+  setContentParts: jest.fn(),
+  getResumeState: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock('@hanzochat/api', () => ({
+  sendEvent: jest.fn(),
+  getViolationInfo: jest.fn(),
+  GenerationJobManager: mockGenerationJobManager,
+  decrementPendingRequest: jest.fn().mockResolvedValue(undefined),
+  sanitizeFileForTransmit: jest.fn((file) => file),
+  sanitizeMessageForTransmit: jest.fn((msg) => msg),
+  checkAndIncrementPendingRequest: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+jest.mock('~/server/cleanup', () => ({
+  disposeClient: jest.fn(),
+  clientRegistry: null,
+  requestDataMap: new Map(),
+}));
+jest.mock('~/server/middleware', () => ({ handleAbortError: jest.fn() }));
+jest.mock('~/cache', () => ({ logViolation: jest.fn() }));
+jest.mock('~/models', () => ({ saveMessage: jest.fn().mockResolvedValue(undefined) }));
+
+const AgentController = require('../request');
+
+/** Resolves once the controller settles onto a terminal emit (done or error). */
+const runController = async (response) => {
+  jest.clearAllMocks();
+  mockGenerationJobManager.getResumeState.mockResolvedValue(null);
+
+  const abortController = new AbortController();
+  const createdAt = Date.now();
+  mockGenerationJobManager.createJob.mockResolvedValue({
+    createdAt,
+    abortController,
+    readyPromise: Promise.resolve(),
+    emitter: { on: jest.fn() },
+  });
+  // Job is never "replaced" — same createdAt on re-read.
+  mockGenerationJobManager.getJob.mockResolvedValue({ createdAt });
+
+  const settled = new Promise((resolve) => {
+    mockGenerationJobManager.emitError.mockImplementation(() => resolve('error'));
+    mockGenerationJobManager.emitDone.mockImplementation(() => resolve('done'));
+  });
+
+  const client = {
+    sender: 'AI',
+    contentParts: [],
+    sendMessage: jest.fn().mockResolvedValue({
+      ...response,
+      messageId: 'resp-1',
+      databasePromise: Promise.resolve({ conversation: { conversationId: 'c1', title: 'T' } }),
+    }),
+  };
+  const initializeClient = jest.fn().mockResolvedValue({ client });
+
+  const req = {
+    body: {
+      text: 'hi',
+      conversationId: 'new',
+      parentMessageId: 'p1',
+      endpointOption: { endpoint: 'agents', modelOptions: { model: 'zen5-mini' } },
+    },
+    user: { id: 'u1' },
+  };
+  const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+
+  await AgentController(req, res, jest.fn(), initializeClient, null);
+
+  let timer;
+  const guard = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error('controller never settled')), 2000);
+  });
+  try {
+    return await Promise.race([settled, guard]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+describe('ResumableAgentController empty-response backstop', () => {
+  it('emits an ERROR (not a silent done) when the response has no content', async () => {
+    const outcome = await runController({ text: '', content: [] });
+
+    expect(outcome).toBe('error');
+    expect(mockGenerationJobManager.emitError).toHaveBeenCalledTimes(1);
+    const [, message] = mockGenerationJobManager.emitError.mock.calls[0];
+    expect(String(message)).toMatch(/empty response/i);
+    expect(mockGenerationJobManager.emitDone).not.toHaveBeenCalled();
+  });
+
+  it('emits DONE normally when the response carries content', async () => {
+    const outcome = await runController({
+      text: '',
+      content: [{ type: ContentTypes.TEXT, text: 'a real answer' }],
+    });
+
+    expect(outcome).toBe('done');
+    expect(mockGenerationJobManager.emitDone).toHaveBeenCalledTimes(1);
+    expect(mockGenerationJobManager.emitError).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/controllers/agents/emptyResponse.js
+++ b/api/server/controllers/agents/emptyResponse.js
@@ -1,0 +1,58 @@
+const { ContentTypes } = require('librechat-data-provider');
+
+/**
+ * Content-part types whose payload is a plain string and which render nothing
+ * when that string is empty. Everything else (error, tool_call, image, audio,
+ * agent_update, ...) renders some visible affordance even without text.
+ */
+const TEXT_LIKE_TYPES = new Set([ContentTypes.TEXT, ContentTypes.THINK, ContentTypes.TEXT_DELTA]);
+
+/**
+ * True when an assembled agent response carries nothing the user would see.
+ *
+ * The Hanzo Cloud gateway can end a `stream:true` completion with NO content and
+ * WITHOUT throwing — a rejected key or an out-of-credits balance answered as a
+ * 200 `text/event-stream` that yields zero deltas. The agent run then completes
+ * "successfully" with an empty `content` array, so the client renders an empty
+ * assistant bubble instead of a visible error (the GA-blocker silent failure).
+ * Callers use this to detect that case and surface a real error over the SSE
+ * error path instead.
+ *
+ * A response is non-empty if it has any non-whitespace `text`, or any content
+ * part that renders something: a text/think part with non-whitespace text, or
+ * any non-text part (error, tool_call, image, audio, ...).
+ *
+ * @param {{ text?: unknown, content?: unknown } | null | undefined} response
+ * @returns {boolean}
+ */
+function isEmptyAgentResponse(response) {
+  if (!response) {
+    return true;
+  }
+
+  if (typeof response.text === 'string' && response.text.trim() !== '') {
+    return false;
+  }
+
+  const { content } = response;
+  if (!Array.isArray(content) || content.length === 0) {
+    return true;
+  }
+
+  return !content.some((part) => {
+    if (typeof part === 'string') {
+      return part.trim() !== '';
+    }
+    if (part == null || typeof part !== 'object') {
+      return false;
+    }
+    if (TEXT_LIKE_TYPES.has(part.type)) {
+      const value = part[part.type];
+      return typeof value === 'string' && value.trim() !== '';
+    }
+    // Any non-text content part renders a visible affordance on its own.
+    return true;
+  });
+}
+
+module.exports = { isEmptyAgentResponse };

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -10,6 +10,7 @@ const {
   checkAndIncrementPendingRequest,
 } = require('@hanzochat/api');
 const { disposeClient, clientRegistry, requestDataMap } = require('~/server/cleanup');
+const { isEmptyAgentResponse } = require('./emptyResponse');
 const { handleAbortError } = require('~/server/middleware');
 const { logViolation } = require('~/cache');
 const { saveMessage } = require('~/models');
@@ -239,6 +240,19 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         };
 
         const response = await client.sendMessage(text, messageOptions);
+
+        // Backstop against a silent empty assistant bubble. The Hanzo Cloud
+        // gateway can end a `stream:true` completion with no content and WITHOUT
+        // throwing (a rejected key or an out-of-credits balance answered as a
+        // 200 event-stream that yields zero deltas), so the run "succeeds" with
+        // an empty response. Surface it as a real error over the existing SSE
+        // error path (caught below → emitError) instead of emitting an empty
+        // message — a dead key or exhausted balance must never be invisible.
+        if (!job.abortController.signal.aborted && isEmptyAgentResponse(response)) {
+          throw new Error(
+            'The model returned an empty response. This usually means the request was rejected upstream (invalid API key or insufficient credits). Please try again or contact support.',
+          );
+        }
 
         const messageId = response.messageId;
         const endpoint = endpointOption.endpoint;


### PR DESCRIPTION
## Problem (GA blocker, task #91)

A rejected gateway key or an out-of-credits balance can end a `stream:true`
completion with **no content and without throwing** — `api.hanzo.ai` answers as a
`200 text/event-stream` that yields zero deltas — so the agent run "succeeds"
with an empty response and the client renders an **empty assistant bubble**.

This is the exact silent failure behind the dead-guest-key GA blocker: a dead
`HANZO_API_KEY` returned `401 {"msg":"invalid API key"}` which the SSE client
rendered as an empty reply (see `operator/crs/chat.yaml`, `chat-guest-key`
provisioning note). Upstream 401/402 during a stream must never be invisible.

## Fix (least code, one error path)

Backstop in `ResumableAgentController` — right after `client.sendMessage`, if the
assembled response carries no user-visible content and the run was **not**
aborted, `throw`. The throw lands in the **existing** catch →
`GenerationJobManager.emitError` → the `event: error` SSE frame the client
(`useResumableSSE`) already renders as an error bubble. No new SSE plumbing; it
reuses the one error path, so a dead key / exhausted balance can never again be
swallowed.

The emptiness decision is a pure, unit-tested helper `isEmptyAgentResponse`:
non-empty iff there is non-whitespace `text`, a non-blank text/think part, or any
non-text content part (error, tool_call, image, …). An `ERROR` part still renders,
so the gateway-threw path is untouched.

## Proof

- `emptyResponse.spec.js` — 8 cases pinning the predicate (empty content array,
  blank-text-only → empty; text / error / tool_call parts → not empty).
- `emptyResponseController.spec.js` — drives the **real** controller: an empty
  completion emits `error` (not a silent `done`); a completion with content emits
  `done`. This is the forced-error path proven at the server boundary.

```
Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total
```

Lint clean on all four files. Scoped to the chat SSE serving path only.

Note: `hanzo.chat` is currently 502 (no live LibreChat `chat` deployment; operator
CR unreconciled), so a live click-through could not be run; the deterministic
controller test drives the exact empty-completion → `event: error` path instead.

https://claude.ai/code/session_016yg7GPhYdWCh9vpp4HEwLZ