### PR TITLE
feat(analytics): instrument chat with @hanzo/capture

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://hanzo.ai/chat",
   "dependencies": {
     "@hanzo/ui": "npm:@hanzo/ui-shadcn@^5.7.4",
+    "@hanzo/capture": "^0.1.0",
     "@ariakit/react": "^0.4.15",
     "@ariakit/react-core": "^0.4.17",
     "@codesandbox/sandpack-react": "^2.19.10",

--- a/client/src/Providers/AnalyticsProvider.tsx
+++ b/client/src/Providers/AnalyticsProvider.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+  AnalyticsProvider as CaptureProvider,
+  useAnalytics,
+  usePageview,
+} from '@hanzo/capture/react';
+import { useAuthContext } from '~/hooks/AuthContext';
+
+const ANALYTICS_HOST = import.meta.env.VITE_HANZO_ANALYTICS_HOST || 'https://api.hanzo.ai';
+
+/**
+ * Identifies the authenticated user and fires a pageview on every route change.
+ * The provider fires the first pageview itself; this keeps subsequent SPA
+ * navigations tracked. Identity uses the stable user id — never email/PII.
+ */
+function AnalyticsBridge() {
+  const analytics = useAnalytics();
+  const { user, isAuthenticated } = useAuthContext();
+  const { pathname } = useLocation();
+
+  usePageview(pathname);
+
+  const userId = isAuthenticated ? user?.id : undefined;
+  useEffect(() => {
+    if (userId != null && userId) {
+      analytics.identify(userId);
+    }
+  }, [analytics, userId]);
+
+  return null;
+}
+
+/**
+ * First-party product analytics for Hanzo Chat (@hanzo/capture → cloud
+ * /v1/analytics). Mounted inside AuthContextProvider so it can read the live JWT
+ * and the resolved user; anonymous events still flow when no token is present.
+ */
+export default function AnalyticsProvider({ children }: { children: ReactNode }) {
+  const { token } = useAuthContext();
+
+  // Read the live token at capture time without re-creating the config: the
+  // 'session' sentinel (cookie-session auth, no JWT) is treated as anonymous.
+  const tokenRef = useRef<string | undefined>(token);
+  tokenRef.current = token;
+
+  const config = useMemo(
+    () => ({
+      product: 'chat',
+      host: ANALYTICS_HOST,
+      getToken: () => {
+        const value = tokenRef.current;
+        return value && value !== 'session' ? value : undefined;
+      },
+    }),
+    [],
+  );
+
+  return (
+    <CaptureProvider config={config}>
+      <AnalyticsBridge />
+      {children}
+    </CaptureProvider>
+  );
+}

--- a/client/src/Providers/index.ts
+++ b/client/src/Providers/index.ts
@@ -1,5 +1,6 @@
 export { default as AssistantsProvider } from './AssistantsContext';
 export { default as AgentsProvider } from './AgentsContext';
+export { default as AnalyticsProvider } from './AnalyticsProvider';
 export * from './ActivePanelContext';
 export * from './AgentPanelContext';
 export * from './ChatContext';

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -25,6 +25,8 @@ import type {
   EndpointSchemaKey,
 } from '@hanzochat/data-provider';
 import type { SetterOrUpdater } from 'recoil';
+import { useAnalytics } from '@hanzo/capture/react';
+import { EVENTS } from '@hanzo/capture';
 import type { TAskFunction, ExtendedFile } from '~/common';
 import useSetFilesToDelete from '~/hooks/Files/useSetFilesToDelete';
 import useGetSender from '~/hooks/Conversations/useGetSender';
@@ -65,6 +67,7 @@ export default function useChatFunctions({
 }) {
   const navigate = useNavigate();
   const getSender = useGetSender();
+  const analytics = useAnalytics();
   const { user } = useAuthContext();
   const queryClient = useQueryClient();
   const setFilesToDelete = useSetFilesToDelete();
@@ -124,6 +127,16 @@ export default function useChatFunctions({
 
     const ephemeralAgent = getEphemeralAgent(conversationId ?? Constants.NEW_CONVO);
     const isEditOrContinue = isEdited || isContinued;
+
+    // Product analytics: model/endpoint identifiers only — never message content.
+    if (!isRegenerate && !isContinued) {
+      const model = conversation?.model;
+      const isNewConvo = conversationId == null || conversationId === Constants.NEW_CONVO;
+      if (isNewConvo) {
+        analytics.capture(EVENTS.CHAT_STARTED, { endpoint, model });
+      }
+      analytics.capture(EVENTS.CHAT_MESSAGE_SENT, { endpoint, model });
+    }
 
     let currentMessages: TMessage[] | null = overrideMessages ?? getMessages() ?? [];
 

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -13,6 +13,7 @@ import { MarketplaceProvider } from '~/components/Agents/MarketplaceContext';
 import AgentMarketplace from '~/components/Agents/Marketplace';
 import { OAuthSuccess, OAuthError } from '~/components/OAuth';
 import { AuthContextProvider } from '~/hooks/AuthContext';
+import { AnalyticsProvider } from '~/Providers';
 import RouteErrorBoundary from './RouteErrorBoundary';
 import BuildRoute from './BuildRoute';
 import StartupLayout from './Layouts/Startup';
@@ -25,8 +26,10 @@ import Root from './Root';
 
 const AuthLayout = () => (
   <AuthContextProvider>
-    <Outlet />
-    <ApiErrorWatcher />
+    <AnalyticsProvider>
+      <Outlet />
+      <ApiErrorWatcher />
+    </AnalyticsProvider>
   </AuthContextProvider>
 );
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -23,7 +23,9 @@
       "~/*": ["./client/src/*"],
       "test/*": ["./client/test/*"],
       "*": ["./client/*", "../node_modules/*"],
-      "@hanzochat/data-provider/*": ["./packages/data-provider/*"]
+      "@hanzochat/data-provider/*": ["./packages/data-provider/*"],
+      "@hanzo/capture": ["./node_modules/@hanzo/capture/dist/index.d.ts"],
+      "@hanzo/capture/react": ["./node_modules/@hanzo/capture/dist/react.d.ts"]
     }
   },
   "types": ["node", "jest", "@testing-library/jest-dom"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       '@dicebear/core':
         specifier: ^9.2.2
         version: 9.4.2
+      '@hanzo/capture':
+        specifier: ^0.1.0
+        version: 0.1.1(react@18.3.1)
       '@hanzo/iam':
         specifier: ^0.13.1
         version: 0.13.1(react@18.3.1)
@@ -3783,6 +3786,14 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hanzo/capture@0.1.1':
+    resolution: {integrity: sha512-Sn5AVtEAzQ8+2cKw9ryMLeOTVzQygijzsYSTZIlF2KUZUPC82BAT5E4U/A04/PqfvupaH9oZpXI+I08ovAYOXA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@hanzo/iam@0.13.1':
     resolution: {integrity: sha512-MAqXY7jL5pcPkaUE0Qb/ePL2WKvk3p6EQDLHGZENj+/gbNKs7e/9qG+nmRlPMFVcwXPk+suzkBAEyIMT2EiJ8w==}
@@ -17672,6 +17683,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
+
+  '@hanzo/capture@0.1.1(react@18.3.1)':
+    optionalDependencies:
+      react: 18.3.1
 
   '@hanzo/iam@0.13.1(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## What

Adds the shared first-party product-analytics client `@hanzo/capture` to the chat client as an **additive** path alongside the existing server-side `INSIGHTS_HOST`/Umami snippet (those are untouched).

Emits to cloud `/v1/analytics` (`+ /v1/tracker`); the server stamps the tenant from the JWT. Anonymous events still flow when no token is present.

## Changes

- **`client/src/Providers/AnalyticsProvider.tsx`** (new) — wraps `@hanzo/capture/react`'s `AnalyticsProvider`, mounted **inside** `AuthContextProvider` so it reads the live JWT via `useAuthContext().token` and the resolved user. Config: `{ product: 'chat', host, getToken }`. Host defaults to `https://api.hanzo.ai` (override: `VITE_HANZO_ANALYTICS_HOST`). `getToken` reads the token through a ref so the config stays stable, and treats the `'session'` sentinel (cookie-session auth, no JWT) as anonymous.
- **`routes/index.tsx`** — `AuthLayout` now renders `<AnalyticsProvider>` around the `<Outlet/>`. A small bridge fires route-change pageviews via `usePageview(useLocation().pathname)` (the provider auto-fires the first pageview) and `identify()`'s the authenticated user on the stable `user.id` — **never email**.
- **`hooks/Chat/useChatFunctions.ts`** — instruments the single `ask()` funnel that every send flows through: fires `CHAT_STARTED` on the first message into a new conversation and `CHAT_MESSAGE_SENT` on each user send, with props `{ endpoint, model }` — **identifiers only**. Regenerate/continue are excluded (not user messages).
- **`client/package.json`** — adds `@hanzo/capture ^0.1.0`.

## Privacy

No message content, prompts, completions, file names, or PII are ever captured — only model/endpoint name identifiers and the stable user id. `identify()` uses `user.id`, never `user.email`.

## Surfaces instrumented

| Event | Location |
| --- | --- |
| pageview | AnalyticsProvider.tsx -> usePageview(useLocation().pathname) (+ provider initial) |
| identify | AnalyticsProvider.tsx -> AnalyticsBridge effect on user.id |
| CHAT_STARTED | hooks/Chat/useChatFunctions.ts -> ask() (first message, new convo) |
| CHAT_MESSAGE_SENT | hooks/Chat/useChatFunctions.ts -> ask() (each user send) |

## Build / ordering dependency

`@hanzo/capture` publishes from the `ui` monorepo. Until that lands on the registry, `npm/pnpm install` and typecheck cannot resolve it — an **expected ordering dependency**, not vendored. The only typecheck errors on touched files are `TS2307 Cannot find module '@hanzo/capture'`; all other types are sound.

Login/signup `SIGNUP_*` events were intentionally left out: prod runs OIDC-only with registration disabled, so there is no first-party signup form to instrument here.