### PR TITLE
refactor: repoint reward-signal client onto shared @hanzo/ai SDK

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://hanzo.ai/chat",
   "dependencies": {
+    "@hanzo/ai": "^0.2.1",
     "@hanzo/ui": "npm:@hanzo/ui-shadcn@^5.7.4",
     "@hanzo/capture": "^0.1.0",
     "@ariakit/react": "^0.4.15",

--- a/client/src/utils/rewardSignal.ts
+++ b/client/src/utils/rewardSignal.ts
@@ -1,41 +1,30 @@
 import axios from 'axios';
+import { sendFeedback, type FeedbackSignal } from '@hanzo/ai';
 
 /**
  * CONTENT-FREE reward signals emitted to the Hanzo gateway (`POST {base}/v1/feedback`)
  * so router training gets production feedback.
  *
- * The payload carries ONLY `{ request_id, signal, rating? }` — never any prompt, response,
- * tag, free-text, filename, or code. `request_id` is the upstream gateway response id
- * (`chatcmpl-…`/`msg_…`) that the routing ledger keys each RoutingEvent on; the chat client
- * receives it as a message's `feedbackRequestId`. When it is missing (e.g. a direct,
- * non-gateway provider path) the signal simply no-ops — we never fabricate an id.
+ * THIN adapter over the shared `@hanzo/ai` `sendFeedback` client (one
+ * implementation, N surfaces): the SDK owns the whitelisted
+ * `{ request_id, signal, rating? }` body, the dedupe, and the fire-and-forget
+ * transport (keepalive fetch / sendBeacon). This module only supplies the
+ * chat-specific base URL, the end-user bearer, and the local opt-out.
  *
- * Transport is fire-and-forget: it NEVER blocks UX and is a SILENT no-op on any failure.
+ * `requestId` is the message's `feedbackRequestId` — the upstream gateway
+ * response id (`chatcmpl-…` / `msg_…`) the routing ledger keys each RoutingEvent
+ * on; when it is missing (a direct, non-gateway provider path) the signal simply
+ * no-ops — we never fabricate an id. No prompt, response, tag, filename or code
+ * can ever transit; it NEVER blocks UX and is a SILENT no-op on any failure.
  */
-export type RewardSignal =
-  | 'up'
-  | 'down'
-  | 'regenerate'
-  | 'switch'
-  | 'abandon'
-  | 'accept'
-  | 'revert'
-  | 'rating';
-
-type RewardSignalBody = {
-  request_id: string;
-  signal: RewardSignal;
-  rating?: number;
-};
-
-/** Dedupe key set — avoids double-sending the same signal for the same message id. */
-const sent = new Set<string>();
+export type RewardSignal = FeedbackSignal;
 
 /**
  * Whether reward-signal emission is disabled via the local opt-out flag.
  *
- * Server-side org/user training opt-in is the PREFERRED enforcement and, when present,
- * makes this client gating redundant — but the client still honors the local opt-out.
+ * Server-side org/user training opt-in is the PREFERRED enforcement and, when
+ * present, makes this client gating redundant — but the client still honors the
+ * local opt-out.
  */
 function isOptedOut(): boolean {
   const flag = import.meta.env.VITE_HANZO_FEEDBACK;
@@ -47,17 +36,14 @@ function isOptedOut(): boolean {
  *
  * @param requestId - The message's `feedbackRequestId` (upstream gateway response id). No-op if absent.
  * @param signal - The reward signal.
- * @param rating - Only sent when `signal === 'rating'` (0-3).
+ * @param rating - Only sent when `signal === 'rating'` (1-3).
  */
 export function sendRewardSignal(
   requestId: string | null | undefined,
   signal: RewardSignal,
   rating?: number,
 ): void {
-  if (!requestId || !signal) {
-    return;
-  }
-  if (isOptedOut()) {
+  if (!requestId || isOptedOut()) {
     return;
   }
 
@@ -66,41 +52,23 @@ export function sendRewardSignal(
     return;
   }
 
-  const body: RewardSignalBody = { request_id: requestId, signal };
-  if (signal === 'rating' && typeof rating === 'number') {
-    body.rating = rating;
-  }
+  // Mirror `setTokenHeader`: forward the end-user bearer for per-org attribution.
+  // `credentials: 'include'` reuses the IAM cross-origin session (the SDK's
+  // default). The SDK re-adds the `Bearer ` prefix, so strip it here.
+  const authorization = axios.defaults.headers.common?.['Authorization'];
+  const token =
+    typeof authorization === 'string' && authorization
+      ? authorization.replace(/^Bearer\s+/i, '')
+      : undefined;
 
-  const dedupeKey =
-    signal === 'rating' ? `${requestId}:${signal}:${body.rating}` : `${requestId}:${signal}`;
-  if (sent.has(dedupeKey)) {
+  const opts = { baseUrl: String(base), token, credentials: 'include' as const };
+
+  if (signal === 'rating') {
+    if (rating !== 1 && rating !== 2 && rating !== 3) {
+      return;
+    }
+    sendFeedback({ requestId, signal, rating }, opts);
     return;
   }
-  sent.add(dedupeKey);
-
-  try {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    /** Mirror `setTokenHeader`: forward the end-user bearer for per-org attribution. */
-    const authorization = axios.defaults.headers.common?.['Authorization'];
-    if (typeof authorization === 'string' && authorization) {
-      headers['Authorization'] = authorization;
-    }
-
-    /**
-     * Dedicated cross-origin call to the Hanzo API — NOT the same-origin chat backend.
-     * `credentials: 'include'` reuses the IAM cross-origin session; `keepalive` lets late
-     * signals (switch/abandon) survive navigation.
-     */
-    void fetch(`${String(base).replace(/\/+$/, '')}/v1/feedback`, {
-      method: 'POST',
-      credentials: 'include',
-      keepalive: true,
-      headers,
-      body: JSON.stringify(body),
-    }).catch(() => {
-      /* silent no-op */
-    });
-  } catch {
-    /* silent no-op */
-  }
+  sendFeedback({ requestId, signal }, opts);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ importers:
         version: 1.46.0(@modelcontextprotocol/sdk@1.22.0(@cfworker/json-schema@4.1.1))
       '@hanzochat/agents':
         specifier: ^3.2.63
-        version: 3.2.63(@aws-sdk/credential-provider-node@3.972.67)(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(@smithy/signature-v4@5.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod@3.25.76)
+        version: 3.2.63(@aws-sdk/credential-provider-node@3.972.67)(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(@smithy/signature-v4@5.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod@3.25.76)
       '@hanzochat/api':
         specifier: workspace:*
         version: link:../packages/api
@@ -376,6 +376,9 @@ importers:
       '@dicebear/core':
         specifier: ^9.2.2
         version: 9.4.2
+      '@hanzo/ai':
+        specifier: ^0.2.1
+        version: 0.2.1
       '@hanzo/capture':
         specifier: ^0.1.0
         version: 0.1.1(react@18.3.1)
@@ -772,7 +775,7 @@ importers:
         version: 1.42.0(@modelcontextprotocol/sdk@1.22.0(@cfworker/json-schema@4.1.1))
       '@hanzochat/agents':
         specifier: ^3.2.63
-        version: 3.2.63(@aws-sdk/credential-provider-node@3.972.67)(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(@smithy/signature-v4@5.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod@3.25.76)
+        version: 3.2.63(@aws-sdk/credential-provider-node@3.972.67)(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(@smithy/signature-v4@5.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod@3.25.76)
       '@hanzochat/data-schemas':
         specifier: workspace:*
         version: link:../data-schemas
@@ -3786,6 +3789,10 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hanzo/ai@0.2.1':
+    resolution: {integrity: sha512-m0k6V6Im8m5RXWHUy/E7DvpZ9tFBYUw21NTYFxNxUiPI1l+yEvHEVytqEbEtHZOCa9Ytb8nfuNzJIsfCeF/zZw==}
+    engines: {node: '>=18'}
 
   '@hanzo/capture@0.1.1':
     resolution: {integrity: sha512-Sn5AVtEAzQ8+2cKw9ryMLeOTVzQygijzsYSTZIlF2KUZUPC82BAT5E4U/A04/PqfvupaH9oZpXI+I08ovAYOXA==}
@@ -17684,6 +17691,8 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
+  '@hanzo/ai@0.2.1': {}
+
   '@hanzo/capture@0.1.1(react@18.3.1)':
     optionalDependencies:
       react: 18.3.1
@@ -17777,7 +17786,7 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@hanzochat/agents@3.2.63(@aws-sdk/credential-provider-node@3.972.67)(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(@smithy/signature-v4@5.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod@3.25.76)':
+  '@hanzochat/agents@3.2.63(@aws-sdk/credential-provider-node@3.972.67)(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(@smithy/signature-v4@5.6.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.103.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1086.0
@@ -17795,7 +17804,7 @@ snapshots:
       '@langchain/textsplitters': 1.0.1(@langchain/core@1.2.2(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.67)(@smithy/signature-v4@5.6.4)(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))
       '@langchain/xai': 1.4.5(@aws-sdk/credential-provider-node@3.972.67)(@langchain/core@1.2.2(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.67)(@smithy/signature-v4@5.6.4)(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@smithy/signature-v4@5.6.4)(ws@8.20.0)
       '@langfuse/langchain': 5.9.1(@langchain/core@1.2.2(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.67)(@smithy/signature-v4@5.6.4)(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@opentelemetry/api@1.9.0)
-      '@langfuse/otel': 5.9.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))
+      '@langfuse/otel': 5.9.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))
       '@langfuse/tracing': 5.9.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/context-async-hooks': 2.9.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.220.0(@opentelemetry/api@1.9.0)
@@ -18540,12 +18549,12 @@ snapshots:
       '@langfuse/tracing': 5.9.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
 
-  '@langfuse/otel@5.9.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))':
+  '@langfuse/otel@5.9.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.220.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.0)
 
   '@langfuse/tracing@5.9.1(@opentelemetry/api@1.9.0)':


### PR DESCRIPTION
## What
Repoints hanzo.chat's content-free reward-signal client onto the shared **`@hanzo/ai` `sendFeedback`** (v0.2.1) — one client, N surfaces (DRY). Transport, dedupe, and the `{request_id, signal, rating?}` whitelist now live once, in the SDK (`hanzo-js/ai#1`, published to npm).

`client/src/utils/rewardSignal.ts` becomes a **thin adapter**:
- keeps the exact public `sendRewardSignal(requestId, signal, rating?)` — message-actions (thumbs / regenerate) and model-selector (switch) surfaces **unchanged**;
- keeps the local `VITE_HANZO_FEEDBACK` opt-out;
- delegates to `sendFeedback({...}, { baseUrl, token, credentials })` with `VITE_HANZO_API_URL` (cross-origin gateway) and the end-user bearer lifted from axios defaults.

## Content-free invariant
Type-enforced by the SDK: a rating can only ride `signal: "rating"`, `dismiss` can never carry one, wire body built field-by-field — no prompt/response/code can transit.

## Tests
`client/src/utils/rewardSignal.spec.ts` — **13/13 passed, untouched**.

## Depends on
`@hanzo/ai@0.2.1` (published to npm).

Claude-Session: https://claude.ai/code/session_015Z1iLf7QBrq1LhignJrzDw